### PR TITLE
multi monitor support

### DIFF
--- a/daemon/Background.js
+++ b/daemon/Background.js
@@ -66,7 +66,9 @@ class Background extends Clutter.Actor {
     this._settings.connect('changed::preview-on-right-side', () => {
       if (this._previewMode) {
         // Set x accounting monitor x as a starting point
-        this.x = this._settings.get_boolean('preview-on-right-side') ? this.width + Main.layoutManager.currentMonitor.x : Main.layoutManager.currentMonitor.x;
+        this.x = this._settings.get_boolean('preview-on-right-side') ?
+            this.width + Main.layoutManager.currentMonitor.x :
+            Main.layoutManager.currentMonitor.x;
       }
     });
 
@@ -111,16 +113,20 @@ class Background extends Clutter.Actor {
       this._controlButtons.visible = true;
 
       // Set background size to one half of the monitor.
-      this.width = Main.layoutManager.currentMonitor.width / 2;
+      this.width  = Main.layoutManager.currentMonitor.width / 2;
       this.height = Main.layoutManager.currentMonitor.height;
       // Set x accounting monitor x as a starting point
-      this.x     = this._settings.get_boolean('preview-on-right-side') ? this.width + Main.layoutManager.currentMonitor.x : Main.layoutManager.currentMonitor.x;
-      this.y     = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
+      this.x = this._settings.get_boolean('preview-on-right-side') ?
+          this.width + Main.layoutManager.currentMonitor.x :
+          Main.layoutManager.currentMonitor.x;
+      this.y =
+          Main.layoutManager.currentMonitor.y;  // Needed for vertical monitor alignment
       // Do not draw outside our preview-mode screen-side.
       this.set_clip(0, 0, this.width, this.height);
 
       // Put control buttons at the lower center.
-      this._controlButtons.x = Main.layoutManager.currentMonitor.width / 4 - this._controlButtons.width / 2;
+      this._controlButtons.x =
+          Main.layoutManager.currentMonitor.width / 4 - this._controlButtons.width / 2;
       this._controlButtons.y = Main.layoutManager.currentMonitor.height - 150;
 
     } else {
@@ -130,8 +136,10 @@ class Background extends Clutter.Actor {
       this._controlButtons.visible = false;
       this.width                   = Main.layoutManager.currentMonitor.width;
       this.height                  = Main.layoutManager.currentMonitor.height;
-      this.x                       = Main.layoutManager.currentMonitor.x; // Needed for horizontal monitor alignment
-      this.y                       = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
+      this.x =
+          Main.layoutManager.currentMonitor.x;  // Needed for horizontal monitor alignment
+      this.y =
+          Main.layoutManager.currentMonitor.y;  // Needed for vertical monitor alignment
 
       // Remove any previous clips set in preview mode.
       this.remove_clip();

--- a/daemon/Background.js
+++ b/daemon/Background.js
@@ -65,7 +65,8 @@ class Background extends Clutter.Actor {
     // Switch monitor side when the preview-on-right-side settings key changes.
     this._settings.connect('changed::preview-on-right-side', () => {
       if (this._previewMode) {
-        this.x = this._settings.get_boolean('preview-on-right-side') ? this.width : 0;
+        // Set x accounting monitor x as a starting point
+        this.x = this._settings.get_boolean('preview-on-right-side') ? this.width + Main.layoutManager.currentMonitor.x : Main.layoutManager.currentMonitor.x;
       }
     });
 
@@ -111,14 +112,14 @@ class Background extends Clutter.Actor {
 
       // Set background size to one half of the monitor.
       this.width = Main.layoutManager.currentMonitor.width / 2;
-      this.x     = this._settings.get_boolean('preview-on-right-side') ? this.width : 0;
-
+      // Set x accounting monitor x as a starting point
+      this.x     = this._settings.get_boolean('preview-on-right-side') ? this.width + Main.layoutManager.currentMonitor.x : Main.layoutManager.currentMonitor.x;
+      this.y     = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
       // Do not draw outside our preview-mode screen-side.
       this.set_clip(0, 0, this.width, this.height);
 
       // Put control buttons at the lower center.
-      this._controlButtons.x =
-          Main.layoutManager.currentMonitor.width / 4 - this._controlButtons.width / 2;
+      this._controlButtons.x = Main.layoutManager.currentMonitor.width / 4 - this._controlButtons.width / 2;
       this._controlButtons.y = Main.layoutManager.currentMonitor.height - 150;
 
     } else {
@@ -127,7 +128,8 @@ class Background extends Clutter.Actor {
       // grabbing the complete user input.
       this._controlButtons.visible = false;
       this.width                   = Main.layoutManager.currentMonitor.width;
-      this.x                       = 0;
+      this.x                       = Main.layoutManager.currentMonitor.x; // Needed for horizontal monitor alignment
+      this.y                       = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
 
       // Remove any previous clips set in preview mode.
       this.remove_clip();

--- a/daemon/Background.js
+++ b/daemon/Background.js
@@ -112,6 +112,7 @@ class Background extends Clutter.Actor {
 
       // Set background size to one half of the monitor.
       this.width = Main.layoutManager.currentMonitor.width / 2;
+      this.height = Main.layoutManager.currentMonitor.height;
       // Set x accounting monitor x as a starting point
       this.x     = this._settings.get_boolean('preview-on-right-side') ? this.width + Main.layoutManager.currentMonitor.x : Main.layoutManager.currentMonitor.x;
       this.y     = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
@@ -128,6 +129,7 @@ class Background extends Clutter.Actor {
       // grabbing the complete user input.
       this._controlButtons.visible = false;
       this.width                   = Main.layoutManager.currentMonitor.width;
+      this.height                  = Main.layoutManager.currentMonitor.height;
       this.x                       = Main.layoutManager.currentMonitor.x; // Needed for horizontal monitor alignment
       this.y                       = Main.layoutManager.currentMonitor.y; // Needed for vertical monitor alignment
 

--- a/daemon/Menu.js
+++ b/daemon/Menu.js
@@ -216,17 +216,22 @@ var Menu = class Menu {
       this._menuSelectionChain.unshift(child);
 
       // The newly active item will be shown at the pointer position. To prevent it from
-      // going offscreen, we clamp the position to the current monitor bounds (we do it removing background boundaries from mouse pointer).
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
+      // going offscreen, we clamp the position to the current monitor bounds (we do it
+      // removing background boundaries from mouse pointer).
+      const [clampedX, clampedY] = this._clampToToMonitor(
+          pointerX - this._background.x, pointerY - this._background.y, 10);
 
-      // Warp the mouse pointer to this position if necessary accounting background position as well.
+      // Warp the mouse pointer to this position if necessary accounting background
+      // position as well.
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
+        this._input.warpPointer(
+            clampedX + this._background.x, clampedY + this._background.y);
       }
 
       // Move the child to the target position accounting background position as well.
       const [ok, relativeX, relativeY] = parent.transform_stage_point(clampedX, clampedY);
-      child.set_translation(relativeX + this._background.x, relativeY + this._background.y, 0);
+      child.set_translation(
+          relativeX + this._background.x, relativeY + this._background.y, 0);
 
       // The "trace" of the menu needs to be "idealized". That means, even if the user did
       // not click exactly in the direction of the item, the line connecting parent and
@@ -244,8 +249,7 @@ var Menu = class Menu {
       });
 
       this._selectionWedges.setItemAngles(itemAngles, (child.angle + 180) % 360);
-      this._selectionWedges.set_translation(
-          clampedX, clampedY, 0);
+      this._selectionWedges.set_translation(clampedX, clampedY, 0);
 
       // This recursively redraws all children based on their newly assigned state.
       this._root.redraw();
@@ -293,13 +297,17 @@ var Menu = class Menu {
       this._menuSelectionChain.shift();
 
       // The parent item will be moved to the pointer position. To prevent it from
-      // going offscreen, we clamp the position to the current monitor bounds (we do it removing background boundaries from mouse pointer).
+      // going offscreen, we clamp the position to the current monitor bounds (we do it
+      // removing background boundaries from mouse pointer).
       const [pointerX, pointerY] = global.get_pointer();
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
+      const [clampedX, clampedY] = this._clampToToMonitor(
+          pointerX - this._background.x, pointerY - this._background.y, 10);
 
-      // Warp the mouse pointer to this position if necessary accounting background position as well.
+      // Warp the mouse pointer to this position if necessary accounting background
+      // position as well.
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
+        this._input.warpPointer(
+            clampedX + this._background.x, clampedY + this._background.y);
       }
 
       // The "trace" of the menu needs to be "idealized". That means, even if the user did
@@ -324,8 +332,7 @@ var Menu = class Menu {
         this._selectionWedges.setItemAngles(itemAngles);
       }
 
-      this._selectionWedges.set_translation(
-          clampedX, clampedY, 0);
+      this._selectionWedges.set_translation(clampedX, clampedY, 0);
 
       // Once the parent is selected, nothing is dragged anymore. Even if the mouse button
       // is still pressed (we might come here when a gesture was detected by the
@@ -438,8 +445,9 @@ var Menu = class Menu {
     });
     this._selectionWedges.setItemAngles(itemAngles);
 
-    // Calculate menu position. We open the menu in the middle of the screen if necessary accounting background position as well.
-    // Else we position it at the mouse pointer accounting background position as well.
+    // Calculate menu position. We open the menu in the middle of the screen if necessary
+    // accounting background position as well. Else we position it at the mouse pointer
+    // accounting background position as well.
     if (previewMode || structure.centered) {
       const posX = this._background.width / 2;
       const posY = this._background.height / 2;
@@ -451,12 +459,14 @@ var Menu = class Menu {
       }
     } else {
       const [pointerX, pointerY] = global.get_pointer();
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
+      const [clampedX, clampedY] = this._clampToToMonitor(
+          pointerX - this._background.x, pointerY - this._background.y, 10);
       this._root.set_translation(clampedX, clampedY, 0);
       this._selectionWedges.set_translation(clampedX, clampedY, 0);
 
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
+        this._input.warpPointer(
+            clampedX + this._background.x, clampedY + this._background.y);
       }
     }
 

--- a/daemon/Menu.js
+++ b/daemon/Menu.js
@@ -216,17 +216,17 @@ var Menu = class Menu {
       this._menuSelectionChain.unshift(child);
 
       // The newly active item will be shown at the pointer position. To prevent it from
-      // going offscreen, we clamp the position to the current monitor bounds.
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX, pointerY, 10);
+      // going offscreen, we clamp the position to the current monitor bounds (we do it removing background boundaries from mouse pointer).
+      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
 
-      // Warp the mouse pointer to this position if necessary.
+      // Warp the mouse pointer to this position if necessary accounting background position as well.
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX, clampedY);
+        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
       }
 
-      // Move the child to the target position.
+      // Move the child to the target position accounting background position as well.
       const [ok, relativeX, relativeY] = parent.transform_stage_point(clampedX, clampedY);
-      child.set_translation(relativeX, relativeY, 0);
+      child.set_translation(relativeX + this._background.x, relativeY + this._background.y, 0);
 
       // The "trace" of the menu needs to be "idealized". That means, even if the user did
       // not click exactly in the direction of the item, the line connecting parent and
@@ -234,7 +234,7 @@ var Menu = class Menu {
       // shown directly at the pointer position, we must move the parent so that the trace
       // has the correct angle. Actually not the parent item has to move but the root of
       // the entire menu selection chain.
-      this._idealizeTace(clampedX, clampedY);
+      this._idealizeTace(clampedX + this._background.x, clampedY + this._background.y);
 
       // Now we update position and the number of wedges of the SelectionWedges
       // according to the newly active item.
@@ -245,7 +245,7 @@ var Menu = class Menu {
 
       this._selectionWedges.setItemAngles(itemAngles, (child.angle + 180) % 360);
       this._selectionWedges.set_translation(
-          clampedX - this._background.x, clampedY - this._background.y, 0);
+          clampedX, clampedY, 0);
 
       // This recursively redraws all children based on their newly assigned state.
       this._root.redraw();
@@ -293,13 +293,13 @@ var Menu = class Menu {
       this._menuSelectionChain.shift();
 
       // The parent item will be moved to the pointer position. To prevent it from
-      // going offscreen, we clamp the position to the current monitor bounds.
+      // going offscreen, we clamp the position to the current monitor bounds (we do it removing background boundaries from mouse pointer).
       const [pointerX, pointerY] = global.get_pointer();
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX, pointerY, 10);
+      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
 
-      // Warp the mouse pointer to this position if necessary.
+      // Warp the mouse pointer to this position if necessary accounting background position as well.
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX, clampedY);
+        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
       }
 
       // The "trace" of the menu needs to be "idealized". That means, even if the user did
@@ -308,7 +308,7 @@ var Menu = class Menu {
       // shown directly at the pointer position, we must move the parent so that the trace
       // has the correct angle. Actually not the parent item has to move but the root of
       // the entire menu selection chain.
-      this._idealizeTace(clampedX, clampedY);
+      this._idealizeTace(clampedX + this._background.x, clampedY + this._background.y);
 
       // Now we update position and the number of wedges of the SelectionWedges
       // according to the newly active item.
@@ -325,7 +325,7 @@ var Menu = class Menu {
       }
 
       this._selectionWedges.set_translation(
-          clampedX - this._background.x, clampedY - this._background.y, 0);
+          clampedX, clampedY, 0);
 
       // Once the parent is selected, nothing is dragged anymore. Even if the mouse button
       // is still pressed (we might come here when a gesture was detected by the
@@ -438,8 +438,8 @@ var Menu = class Menu {
     });
     this._selectionWedges.setItemAngles(itemAngles);
 
-    // Calculate menu position. We open the menu in the middle of the screen if necessary.
-    // Else we position it at the mouse pointer.
+    // Calculate menu position. We open the menu in the middle of the screen if necessary accounting background position as well.
+    // Else we position it at the mouse pointer accounting background position as well.
     if (previewMode || structure.centered) {
       const posX = this._background.width / 2;
       const posY = this._background.height / 2;
@@ -447,16 +447,16 @@ var Menu = class Menu {
       this._selectionWedges.set_translation(posX, posY, 0);
 
       if (!previewMode) {
-        this._input.warpPointer(posX, posY);
+        this._input.warpPointer(posX + this._background.x, posY + this._background.y);
       }
     } else {
       const [pointerX, pointerY] = global.get_pointer();
-      const [clampedX, clampedY] = this._clampToToMonitor(pointerX, pointerY, 10);
+      const [clampedX, clampedY] = this._clampToToMonitor(pointerX - this._background.x, pointerY - this._background.y, 10);
       this._root.set_translation(clampedX, clampedY, 0);
       this._selectionWedges.set_translation(clampedX, clampedY, 0);
 
       if (pointerX != clampedX || pointerY != clampedY) {
-        this._input.warpPointer(clampedX, clampedY);
+        this._input.warpPointer(clampedX + this._background.x, clampedY + this._background.y);
       }
     }
 


### PR DESCRIPTION
Hi, I added multi monitor support to Fly-Pie.
It was done by setting the background x and y to the current monitor x and y, then keeping everything relative to the background.

By the way, only the current monitor is used. If you wish to accomplish a ore complicated effect like using the merged surface of all monitors let me know! :-)
(It'll be fantastic to have such an option into fly pie, choosing to use only the current monitor or all the monitor together)