### PR TITLE
Check prerequisites before attempting to compile locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ Once you are happy with your translation, save a `<country code>.po` file in the
 ./compile-locales.sh
 ```
 
+In order for this to work, you'll need to install the `gettext` package. In Ubuntu 20.04 and 20.10, it can be installed by running the following command:
+
+```bash
+sudo apt install gettext
+```
+
 Then restart Gnome Shell with <kbd>Alt</kbd> + <kbd>F2</kbd>, <kbd>r</kbd> + <kbd>Enter</kbd>.
 Or logout / login if you are on Wayland.
 

--- a/compile-locales.sh
+++ b/compile-locales.sh
@@ -13,6 +13,11 @@
 
 # Get the location of this script.
 FLYPIE="$( cd "$( dirname "$0" )" && pwd )"
+# Check if all necessary commands are available
+if ! which msgfmt; then
+  echo "ERROR: Could not find msgfmt. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+fi
 
 for FILE in `ls $FLYPIE/po/*.po`
 do

--- a/compile-locales.sh
+++ b/compile-locales.sh
@@ -13,7 +13,8 @@
 
 # Get the location of this script.
 FLYPIE="$( cd "$( dirname "$0" )" && pwd )"
-# Check if all necessary commands are available
+
+# Check if all necessary commands are available.
 if ! which msgfmt; then
   echo "ERROR: Could not find msgfmt. On Ubuntu based systems, check if the gettext package is installed!"
   exit 1


### PR DESCRIPTION
Add a check if all prerequisites are met before compiling the locales with `compile-locales.sh` and add troubleshooting info in the `README`.
There's still room for improvement here - since I only have an Ubuntu system at my disposal, I cannot provide instructions for other operating systems. The name of the package that provides `msgfmt` could be different for each distro.