### PR TITLE
Add CONTRIBUTING.md and correct typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         ./compile-locales.sh
         mkdir flypie@schneegans.github.com
         mv common daemon presets resources schemas settings locale flypie@schneegans.github.com
-        mv *.js metadata.json README.md LICENSE flypie@schneegans.github.com
+        mv *.js metadata.json *.md LICENSE flypie@schneegans.github.com
         zip -r flypie@schneegans.github.com.zip flypie@schneegans.github.com
     - name: Upload Release
       uses: svenstaro/upload-release-action@v1-release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ The development of Fly-Pie follows a simplified version of **git-flow**: The `ma
 New features and bug fixes are implemented in `feature/*` branches and are merged to `develop` once they are finished.
 When a new milestone is reached, the content of `develop` will be merged to `master` and a tag is created. In rare and critical cases, hotfixes for the latest release will be created in the `master` branch and merged back to `develop`.
 
+Still unclear? [This video](https://www.youtube.com/watch?v=1SXpE08hvGs) provides a good explanation.
+
 ## Git Commit Messages
 
 Commits should start with a Capital letter and should be written in present tense (e.g. __:tada: Add cool new feature__ instead of __:tada: Added cool new feature__).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Fly-Pie
+
+Thank you for contributing your idea to Fly-Pie! Here are some guidelines to help you comply with the workflow used in this project.
+
+## Branching Guidelines
+
+The development of Fly-Pie follows a simplified version of **git-flow**: The `master` branch always contains stable code.
+New features and bug fixes are implemented in `feature/*` branches and are merged to `develop` once they are finished.
+When a new milestone is reached, the content of `develop` will be merged to `master` and a tag is created. In rare and critical cases, hotfixes for the latest release will be created in the `master` branch and merged back to `develop`.
+
+## Git Commit Messages
+
+Commits should start with a Capital letter and should be written in present tense (e.g. __:tada: Add cool new feature__ instead of __:tada: Added cool new feature__).
+You should also start your commit message with **one** applicable emoji. This does not only look great but also makes you rethink what to add to a commit. Make many but small commits!
+
+Emoji | Description
+------|------------
+:tada: `:tada:` | When you added a cool new feature.
+:wrench: `:wrench:` | When you added a piece of code.
+:recycle: `:recycle:` | When you refactored a part of the code.
+:sparkles: `:sparkles:` | When you applied clang-format.
+:globe_with_meridians: `:globe_with_meridians:` | When you worked on translations.
+:art: `:art:` | When you improved / added assets like themes.
+:rocket: `:rocket:` | When you improved performance.
+:memo: `:memo:` | When you wrote documentation.
+:beetle: `:beetle:` | When you fixed a bug.
+:twisted_rightwards_arrows: `:twisted_rightwards_arrows:` | When you merged a branch.
+:fire: `:fire:` | When you removed something.
+:truck: `:truck:` | When you moved / renamed something.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ A great way to contribute to Fly-Pie is creating a translation to another langua
 We suggest using a tool like [Poedit](https://poedit.net/) or the [GNOME Translation Editor](https://wiki.gnome.org/Apps/Gtranslator).
 
 Translations of Fly-Pie are stored in the `po/` directory.
-Just edit an existing translation or create a new one by opening the template [`po/flypie.pot`](po/flypie.pot) with either of this tools.
+Just edit an existing translation or create a new one by opening the template [`po/flypie.pot`](po/flypie.pot) with either of these tools.
 
 Once you are happy with your translation, save a `<country code>.po` file in the `/po` directory and run the following command to compile the strings:
 

--- a/README.md
+++ b/README.md
@@ -217,37 +217,13 @@ report this via [Github issues](https://github.com/schneegans/fly-pie/issues).
 We are happy to receive contributions to Fly-Pie in the form of **pull requests** via Github.
 Feel free to fork the repository, implement your changes and create a merge request to the `develop` branch.
 
+For detailed contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 Developing a Gnome Shell extension is not easy, as debugging possibilities are quite limited. One thing you should always do is to monitor Gnome Shells output for error or debug messages produced by Fly-Pie. This can be done with the command below. This may print many unrelated messages, but using `grep` like this highlights all occurrences of `flypie` which makes spotting Fly-Pie-related messages much easier.
 
 ```bash
 journalctl -f -o cat | grep -E 'flypie|'
 ```
-
-## Branching Guidelines
-
-The development of Fly-Pie follows a simplified version of **git-flow**: The `master` branch always contains stable code.
-New features and bug fixes are implemented in `feature/*` branches and are merged to `develop` once they are finished.
-When a new milestone is reached, the content of `develop` will be merged to `master` and a tag is created. In rare and critical cases, hotfixes for the latest release will be created in the `master` branch and merged back to `develop`.
-
-## Git Commit Messages
-
-Commits should start with a Capital letter and should be written in present tense (e.g. __:tada: Add cool new feature__ instead of __:tada: Added cool new feature__).
-You should also start your commit message with **one** applicable emoji. This does not only look great but also makes you rethink what to add to a commit. Make many but small commits!
-
-Emoji | Description
-------|------------
-:tada: `:tada:` | When you added a cool new feature.
-:wrench: `:wrench:` | When you added a piece of code.
-:recycle: `:recycle:` | When you refactored a part of the code.
-:sparkles: `:sparkles:` | When you applied clang-format.
-:globe_with_meridians: `:globe_with_meridians:` | When you worked on translations.
-:art: `:art:` | When you improved / added assets like themes.
-:rocket: `:rocket:` | When you improved performance.
-:memo: `:memo:` | When you wrote documentation.
-:beetle: `:beetle:` | When you fixed a bug.
-:twisted_rightwards_arrows: `:twisted_rightwards_arrows:` | When you merged a branch.
-:fire: `:fire:` | When you removed something.
-:truck: `:truck:` | When you moved / renamed something.
 
 ## Translating Fly-Pie
 
@@ -273,3 +249,5 @@ Then restart Gnome Shell with <kbd>Alt</kbd> + <kbd>F2</kbd>, <kbd>r</kbd> + <kb
 Or logout / login if you are on Wayland.
 
 You can add your new `*.po` file with a commit like `:globe_with_meridians: Add new translation for <country code>` and submit a pull request!
+
+Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution guidelines.


### PR DESCRIPTION
When moving the contribution guidelines to this file, they show up on the right hand side when creating a Pull Request.
I also added a link to a video that explains `git flow`, for those who have not heard of it yet; and corrected a typo.