### PR TITLE
Add translation PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
@@ -8,7 +8,7 @@ assignees: ''
 
 <!--
 Thank you for contributing a translation to Fly-Pie!
-This template will help you to to provide a high quality contributon to the project.
+This template will help you to provide a high quality contribution to the project.
 Please replace words in pointy <brackets> with suitable replacements.
 
 ---
@@ -32,7 +32,9 @@ is ok with it - but I'm sure they will be! xD)
 
 - [ ] I followed the "Translating FlyPie" section of the README.
 - [ ] I complied to the Contributing Guidelines. <!--see CONTRIBUTING.md-->
-- [ ] I made the following changes to my `<LANGUAGE>.po` file: <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
+- [ ] I tested the translation and checked that nothing looks out-of-place.
+      Especially the strings which are marked with **Keep this short** may break the layout of the user interface if the translation is too long.
+- [ ] I made the following changes to my `<LANGUAGE_CODE>.po` file: <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
   - [ ] Fill in the `<LANGUAGE>`.
   - [ ] In case you are the first translator, fill in your info and the year. If not, just tick this box anyway.
   - [ ] Set `PO_Revision-Date` to an appropriate point in time.
@@ -52,7 +54,10 @@ is ok with it - but I'm sure they will be! xD)
 
 <!--
 This is the place for any additional stuff concerning your Pull Request.
-Please put it below this comment. If there isn't anything else to say, please delete the heading.
+For example, you could drop a note here if you do not want to get notified
+when your translation needs an update in the future.
+If there isn't anything else to say, please delete the heading.
+
 Thanks again for your contribution!
 Your Fly-Pie Team
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
@@ -34,6 +34,7 @@ is ok with it - but I'm sure they will be! xD)
 - [ ] I complied to the Contributing Guidelines. <!--see CONTRIBUTING.md-->
 - [ ] I tested the translation and checked that nothing looks out-of-place.
       Especially the strings which are marked with **Keep this short** may break the layout of the user interface if the translation is too long.
+      <!--When using Poedit or Gtranslator, keep an eye on the comments on the right hand side of the UI!-->
 - [ ] I made the following changes to my `<LANGUAGE_CODE>.po` file: <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
   - [ ] Fill in the `<LANGUAGE>`.
   - [ ] In case you are the first translator, fill in your info and the year. If not, just tick this box anyway.
@@ -43,7 +44,8 @@ is ok with it - but I'm sure they will be! xD)
         <!--Format: Firstname Lastname <my@email.address>.
         Alternatively, use your GitHub handle.-->
   - [ ] Update `Language-Team`. If your name is already on there, just tick this box anyway.
-        <!--Please place your full name or GitHub handle at the end of the comma-seperated list.-->
+        <!--Please place your full name or GitHub handle at the end of the comma-seperated list.
+        This will be used to notify you when a translation needs to be updated (for opt-out, see below).-->
   - [ ] Set `Language` to the language code (`de_DE`, `en_GB`) or just the country code (`de`, `en`).
         <!--If there are special words that are written differently in two countries with the same
         language (e. g. "color" and "colour" in English), the first variant is obligatory.-->

--- a/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
@@ -1,0 +1,58 @@
+---
+name: Add or update a translation
+about: Make Fly-Pie international! 🌐
+title: '<Add/Update> <LANGUAGE> translation'
+labels: translation
+assignees: ''
+---
+
+<!--
+Thank you for contributing a translation to Fly-Pie!
+This template will help you to to provide a high quality contributon to the project.
+Please replace words in pointy <brackets> with suitable replacements.
+
+---
+
+This block of text is a comment - it will not show up in the final version of the
+Pull request, but provide additional info to you on how to do things correctly.
+You should not delete them, in case you would like to look something up later.
+In order to do so once you submitted the PR, click on "edit" in the top right corner.
+-->
+
+## Requirements to get this PR accepted
+
+<!--
+Make sure to comply to all requirements and tick the boxes once you have done the task.
+Look at existing translations for reference. Even if your PR doesn't meet all requirements
+right now, please do submit it anyways! We are a friendly community and eager to help you out.
+
+Once all boxes are ticked, your PR is ready to be merged (providing Fly-Pie's maintainer
+is ok with it - but I'm sure they will be! xD)
+-->
+
+- [ ] I followed the "Translating FlyPie" section of the README.
+- [ ] I complied to the Contributing Guidelines. <!--see CONTRIBUTING.md-->
+- [ ] I made the following changes to my `<LANGUAGE>.po` file: <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
+  - [ ] Fill in the `<LANGUAGE>`.
+  - [ ] In case you are the first translator, fill in your info and the year. If not, just tick this box anyway.
+  - [ ] Set `PO_Revision-Date` to an appropriate point in time.
+        <!--It doesn't have to be accurate to the second, but at least the hour should be accurate.-->
+  - [ ] Set `Last-Translator` accordingly.
+        <!--Format: Firstname Lastname <my@email.address>.
+        Alternatively, use your GitHub handle.-->
+  - [ ] Update `Language-Team`. If your name is already on there, just tick this box anyway.
+        <!--Please place your full name or GitHub handle at the end of the comma-seperated list.-->
+  - [ ] Set `Language` to the language code (`de_DE`, `en_GB`) or just the country code (`de`, `en`).
+        <!--If there are special words that are written differently in two countries with the same
+        language (e. g. "color" and "colour" in English), the first variant is obligatory.-->
+  - [ ] Make sure that `charset` is set to `UTF-8`.
+        <!--This allows for special characters like ä, ö, ü, è etc. to be displayed correctly.-->
+
+## Additional ideas/questions
+
+<!--
+This is the place for any additional stuff concerning your Pull Request.
+Please put it below this comment. If there isn't anything else to say, please delete the heading.
+Thanks again for your contribution!
+Your Fly-Pie Team
+-->

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 # German translation for the Fly-Pie GNOME Shell Extension.
 # Copyright (C) 2020 Simon Schneegans
 # This file is distributed under the same license as the Fly-Pie package.
-# Philipp Kiemle <philipp.kiemle@gmail.com>, 2020.
+# Initial translation: Simon Schneegans <code@simonschneegans.de>, 2020.
 #
 msgid ""
 msgstr ""
@@ -10,7 +10,7 @@ msgstr ""
 "POT-Creation-Date: 2020-11-15 20:51+0100\n"
 "PO-Revision-Date: 2020-11-17 11:31+0100\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
-"Language-Team:  <>\n"
+"Language-Team:  Simon Schneegans <code@simonschneegans.de>, Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/flypie.pot
+++ b/po/flypie.pot
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# <LANGUAGE> translation for the Fly-Pie GNOME Shell Extension.
+# Copyright (C) 2020 Simon Schneegans
+# This file is distributed under the same license as the Fly-Pie package.
+# Initial translation: <FIRST AUTHOR> <EMAIL@ADDRESS>, <YEAR>.
 #
 #, fuzzy
 msgid ""
@@ -9,10 +9,10 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-11-15 20:51+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: <YYYY-MM-DD> <HM:MM+TIMEZONE>\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language-Team: <NAMES OF CONTRIBUTORS>\n"
+"Language: <LANGUAGE_CODE>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,7 +1,7 @@
-# ITALIAN TRANSLATION FOR FLY-PIE.
+# Italian translation for the Fly-Pie GNOME Shell Extension.
 # Copyright (C) 2020 Simon Schneegans.
 # This file is distributed under the same license as the Fly-Pie package.
-# ALBANO BATTISTELLA <albano_battistella@hotmail.com>, 2020.
+# Initial translation: Albano Battistella <albano_battistella@hotmail.com>, 2020.
 #
 msgid ""
 msgstr ""
@@ -12,9 +12,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language-Team: \n"
+"Language-Team: Albano Battistella <albano_battistella@hotmail.com>\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: albano battistella <albano_battistella@hotmail.com>\n"
+"Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: it_IT\n"
 

--- a/po/it.po
+++ b/po/it.po
@@ -16,7 +16,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: it_IT\n"
+"Language: it\n"
 
 #: settings/settings.ui:53
 msgid ""


### PR DESCRIPTION
I added a PR template that encourages contributors to adhere to certain standards.
This ensures a high-quality Pull Request and helps you in the review process. What do you think about the criteria? Should we add something to the checkboxes?

In the header, it automatically adds a `translation` label to the PR - if you want, you could set the [translation board](https://github.com/Schneegans/Fly-Pie/projects/5) up to automatically track the status of PRs and Issues with that label and move them to `done` once they are merged/closed. What do you think about that?

