### PR TITLE
Build test fix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,5 +96,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Fly-Pie
       run: |
+        sudo apt-get update -qq && sudo apt-get install gettext --qq -y
         $GITHUB_WORKSPACE/create-release.sh
         

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,6 +96,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Fly-Pie
       run: |
-        sudo apt-get update -qq && sudo apt-get install gettext --qq -y
+        sudo apt-get update -qq && sudo apt-get install gettext -qq -y
         $GITHUB_WORKSPACE/create-release.sh
         

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -8,6 +8,9 @@
 #                                                                                        #
 # -------------------------------------------------------------------------------------- #
 
+# Exit the script when one command fails.
+set -e
+
 # Get the location of this script.
 SRC_DIR="$( cd "$( dirname "$0" )" && pwd )"
 

--- a/cloc.sh
+++ b/cloc.sh
@@ -14,6 +14,9 @@
 # You can either pass --loc, --comments or  --percentage to show the respective values
 # only.
 
+# Exit the script when one command fails.
+set -e
+
 # Get the location of this script.
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 

--- a/compile-locales.sh
+++ b/compile-locales.sh
@@ -11,6 +11,9 @@
 # This script creates a compiled *.mo translation file for each *.po file in the 'po'
 # directory. It is necessary to run this script whenever a translation has been changed.
 
+# Exit the script when one command fails.
+set -e
+
 # Check if all necessary commands are available.
 if ! command -v msgfmt &> /dev/null
 then

--- a/create-release.sh
+++ b/create-release.sh
@@ -11,6 +11,9 @@
 # This script creates a new release of the Fly-Pie GNOME extension.
 # When the '-i' option is set, it installs it to the system.
 
+# Exit the script when one command fails.
+set -e
+
 # Go to the location of this script.
 cd "$( cd "$( dirname "$0" )" && pwd )" || { echo "ERROR: Could not find the location of 'create-release.sh'."; exit 1; }
 

--- a/update-locales.sh
+++ b/update-locales.sh
@@ -12,6 +12,9 @@
 # the po/flypie.pot file accordingly. The new strings are than merged with all existing
 # translations.
 
+# Exit the script when one command fails.
+set -e
+
 # Check if all necessary commands are available.
 if ! command -v xgettext &> /dev/null
 then


### PR DESCRIPTION
I noticed that the [build test](https://github.com/Schneegans/Fly-Pie/pull/49/checks?check_run_id=1470664352) is successful on your latest PR (#49), when it actually should fail because of two things (see the log I linked to above):
1. `gettext` is not installed in the testing environment
2. The zipping process fails, because there is no `locale` directory. It wasn't created because of the above error.

I already committed a fix for (1) on this branch.
How can we make sure to pass on any error code that might get thrown by a command in our scripts?
Yes, we could query the exit status of each and every command we execute, but there has to be a more elegant solution to this.
I am too tired to work on this right now, but might have a look during next week.
Ideas are very welcome!