### PR TITLE
🌐 Improve translation workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_or_update_translation.md
@@ -25,19 +25,22 @@ is ok with it - but I'm sure they will be! xD)
 - [ ] I followed the "Translating FlyPie" section of the README.
 - [ ] I complied to the Contributing Guidelines. <!--see CONTRIBUTING.md-->
 - [ ] I tested the translation and checked that nothing looks out-of-place.
-      Especially the strings which are marked with **Keep this short** may break the layout of the user interface if the translation is too long.
+      Especially the strings which are marked with **Keep this short** may break the layout of
+      the user interface if the translation is too long.
       <!--When using Poedit or Gtranslator, keep an eye on the comments on the right hand side of the UI!-->
-- [ ] I made the following changes to my `<LANGUAGE_CODE>.po` file: <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
+- [ ] I made the following changes to my `<LANGUAGE_CODE>.po` file:
+      <!--You'll find most of them in the first code block, around lines 1-20-ish.-->
   - [ ] Fill in the `<LANGUAGE>`.
-  - [ ] In case you are the first translator, fill in your info and the year. If not, just tick this box anyway.
+  - [ ] I added myself to the contributors list.
+        <!--Please place your full name and email address or GitHub handle at
+        the end of the first block of comments in the translations file, like this:
+        <Firstname Lastname <emailOrGithubHandle>, <YEAR>.>
+        This will be used to notify you when a translation needs to be updated (for opt-out, see below).-->
   - [ ] Set `PO_Revision-Date` to an appropriate point in time.
         <!--It doesn't have to be accurate to the second, but at least the hour should be accurate.-->
   - [ ] Set `Last-Translator` accordingly.
         <!--Format: Firstname Lastname <my@email.address>.
         Alternatively, use your GitHub handle.-->
-  - [ ] Update `Language-Team`. If your name is already on there, just tick this box anyway.
-        <!--Please place your full name or GitHub handle at the end of the comma-seperated list.
-        This will be used to notify you when a translation needs to be updated (for opt-out, see below).-->
   - [ ] Set `Language` to the language code (`de_DE`, `en_GB`) or just the country code (`de`, `en`).
         <!--If there are special words that are written differently in two countries with the same
         language (e. g. "color" and "colour" in English), the first variant is obligatory.-->

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,8 @@
 # German translation for the Fly-Pie GNOME Shell Extension.
 # Copyright (C) 2020 Simon Schneegans
 # This file is distributed under the same license as the Fly-Pie package.
-# Initial translation: Simon Schneegans <code@simonschneegans.de>, 2020.
+# Simon Schneegans <code@simonschneegans.de>, 2020.
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2020.
 #
 msgid ""
 msgstr ""
@@ -10,8 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2020-12-16 20:36+0100\n"
 "PO-Revision-Date: 2020-11-30 09:24+0100\n"
 "Last-Translator: Simon Schneegans <code@simonschneegans.de>\n"
-"Language-Team: Simon Schneegans <code@simonschneegans.de>, Philipp Kiemle "
-"<philipp.kiemle@gmail.com>\n"
+"Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/flypie.pot
+++ b/po/flypie.pot
@@ -1,7 +1,7 @@
 # <LANGUAGE> translation for the Fly-Pie GNOME Shell Extension.
 # Copyright (C) 2020 Simon Schneegans
 # This file is distributed under the same license as the Fly-Pie package.
-# Initial translation: <FIRST AUTHOR> <EMAIL@ADDRESS>, <YEAR>.
+# <FIRSTNAME LASTNAME> <EMAIL@ADDRESS>, <YEAR>.
 #
 #, fuzzy
 msgid ""
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2020-12-16 20:36+0100\n"
 "PO-Revision-Date: <YYYY-MM-DD> <HM:MM+TIMEZONE>\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: <NAMES OF CONTRIBUTORS>\n"
+"Language-Team: \n"
 "Language: <LANGUAGE_CODE>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,7 +1,7 @@
 # Italian translation for the Fly-Pie GNOME Shell Extension.
 # Copyright (C) 2020 Simon Schneegans.
 # This file is distributed under the same license as the Fly-Pie package.
-# Initial translation: Albano Battistella <albano_battistella@hotmail.com>, 2020.
+# Albano Battistella <albano_battistella@hotmail.com>, 2020.
 #
 msgid ""
 msgstr ""

--- a/update-locales.sh
+++ b/update-locales.sh
@@ -42,6 +42,16 @@ do
   [[ -e "$FILE" ]] || { echo "ERROR: No .po files found, exiting."; exit 1; }
   echo -n "Updating '$FILE' "
   msgmerge -U "$FILE" po/flypie.pot
+
+  # Check if the translation got fuzzy.
+  if grep --silent "#, fuzzy" "$FILE"; then
+    FUZZY+=("$FILE")
+  fi
 done
+
+# Display a warning if any translation needs an update.
+if [[ -v FUZZY ]]; then
+  echo "WARNING: Some translations have unclear strings and need an update: ${FUZZY[*]}"
+fi
 
 echo "All done!"


### PR DESCRIPTION
I recently started to translate GNOME applications and noticed that they put the contributors at the end of the first comment block, not in `Language-Team`, as we handle it at the moment.
This is very sensible, in my opinion!

Furthermore, I added a little code snippet that checks whether translations got fuzzy, meaning that a string changed and the translation may be incorrect.
It does not detect missing translations, however.

What do you think of this?