### PR TITLE
🐞 Fix size check when installing with `-i` (and correct typo)

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -35,8 +35,7 @@ while getopts is FLAG; do
             # shellcheck disable=2015
             gnome-extensions install flypie@schneegans.github.com.zip --force && \
             echo "Successfully installed the application! Now restart the Shell ('Alt'+'F2', then 'r')." || \
-            { echo "ERROR: Could not install the extension."; exit 1; }
-            rm flypie@schneegans.github.com.zip;;
+            { echo "ERROR: Could not install the extension."; exit 1; };;
 
         s)  # We need to throw an error because of the zip size
             SIZE_ERROR="true";;

--- a/create-release.sh
+++ b/create-release.sh
@@ -10,7 +10,7 @@
 
 # This script creates a new release of the Fly-Pie GNOME extension.
 # When the '-i' option is set, it installs it to the system.
-# When the '-s' option is set, the script throws an error (instead of an error when the
+# When the '-s' option is set, the script throws an error (instead of just a warning) when the
 #   zip file is too big. This is necessary when uploading it to the GNOME Extensions website.
 #   We think that the limit is 4096 KB, but we found no official documentation on this so far.
 


### PR DESCRIPTION
When executing `create-release.sh -i`, the size check introduced with #59 doesn't work properly. This is the command output (I cut out the head end a bit):

```bash
  adding: prefs.js (deflated 63%)
  adding: metadata.json (deflated 45%)
  adding: LICENSE (deflated 41%)
Successfully installed the application! Now restart the Shell ('Alt'+'F2', then 'r').
stat: der Aufruf von statx für 'flypie@schneegans.github.com.zip' ist fehlgeschlagen: Datei oder Verzeichnis nicht gefunden
```

This is because the `zip` gets deleted before the size check happens. I thought - why even bother deleting the file? You may want to upload the tested version to the website after all ;)
So I decided that the deletion is not necessary at all. Do you agree?