### PR TITLE
Touch buttons

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 
 #### New Features
 
+* **Touch Buttons** can now be enabled for each configured menu. A touch button is a floating button which can be moved anywhere on your screen and will open the corresponding menu when activated. In fact, you do not need to click the button, you can also start dragging on the button in a specific direction to directly enter the marking mode of the menu.
 * New **Clipboard Menu**: This menu shows recently copied things.
 On selection, the respective item is pasted.
 The menu currently supports text, raster and vector images, and files copied from the file manager.
@@ -19,10 +20,10 @@ When the user presses <kbd>Ctrl</kbd>+<kbd>C</kbd>, the clipboard does not magic
 To store a history of copied things, Fly-Pie has to request the data from the current provider.
 However, it cannot know beforehand, in which format any receiving application would like to have the data.
 So it just makes some assumptions and stores the data in a quite commonly used format and hopes that the receiver will understand the format.
+* Fly-Pie will now attempt to **open windows at the current pointer location** in order to reduce mouse travel. Whenever an action is executed, Fly-Pie checks whether a window is opened within the next second. If this happens, the newly opened window is moved to the pointer.
 * Icons can now be given as [**base64 encoded data URIs**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 This allows creating menus with completely application defined icons.
 * **Two new D-Bus methods** have been added (`ShowMenuAt` and `ShowCustomMenuAt`) which can be used to open a menu at specific pixel coordinates.
-* Fly-Pie will now attempt to **open windows at the current pointer location** in order to reduce mouse travel. Whenever an action is executed, Fly-Pie checks whether a window is opened within the next second. If this happens, the newly opened window is moved to the pointer.
 
 #### Other Enhancements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,8 +19,9 @@ When the user presses <kbd>Ctrl</kbd>+<kbd>C</kbd>, the clipboard does not magic
 To store a history of copied things, Fly-Pie has to request the data from the current provider.
 However, it cannot know beforehand, in which format any receiving application would like to have the data.
 So it just makes some assumptions and stores the data in a quite commonly used format and hopes that the receiver will understand the format.
-* Icons can now be given as [base64 encoded data URIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+* Icons can now be given as [**base64 encoded data URIs**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 This allows creating menus with completely application defined icons.
+* Two **new D-Bus methods** have been added (`ShowMenuAt` and `ShowCustomMenuAt`) which can be used to open a menu at specific pixel coordinates.
 
 #### Other Enhancements
 

--- a/docs/dbus-interface.md
+++ b/docs/dbus-interface.md
@@ -24,7 +24,13 @@ gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/shell/exten
            --method org.gnome.Shell.Extensions.flypie.ShowMenu 'Main Menu'
 ```
 
-There is also a similar method called `PreviewMenu` which will open the given menu in preview mode.
+There is also a similar method called `ShowMenuAt` which will open the given menu at the specified pixel location.
+
+```bash
+gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/shell/extensions/flypie \
+           --method org.gnome.Shell.Extensions.flypie.ShowMenuAt 'Main Menu' 234 456
+```
+Lastly, there is a method called `PreviewMenu` which will open the given menu in preview mode.
 
 ```bash
 gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/shell/extensions/flypie \
@@ -33,7 +39,7 @@ gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/shell/exten
 
 ## Opening Custom Menus via JSON
 
-You can pass a JSON menu configuration to the `ShowCustomMenu` to show a custom menu.
+You can pass a JSON menu configuration to the `ShowCustomMenu` (and `ShowCustomMenuAt`, `PreviewCustomMenu`) to show a custom menu.
 Here is an example showing a menu with two elements.
 Selecting them will change your workspace up or down (by simulating a <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Up</kbd>
 or a <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Down</kbd> respectively).

--- a/resources/img/scalable/actions/flypie-edit-touch-buttons-symbolic.svg
+++ b/resources/img/scalable/actions/flypie-edit-touch-buttons-symbolic.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg881"
+   sodipodi:docname="flypie-edit-touch-buttons-symbolic.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata887">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs885" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     id="namedview883"
+     showgrid="true"
+     inkscape:zoom="53.95614"
+     inkscape:cx="8.0343034"
+     inkscape:cy="7.9323687"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg881"
+     inkscape:document-rotation="0"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-global="false"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid900" />
+  </sodipodi:namedview>
+  <path
+     d="M 1.8839099,8.0082168 C 1.5454978,7.7717469 1.3363405,7.4300293 1.2571978,6.9821804 1.2443112,6.5235701 1.3524101,6.1247257 1.5888699,5.7861705 1.8517762,5.4098872 2.238902,5.1764668 2.7501792,5.0859258 3.287984,4.9575308 3.7447127,5.0249881 4.1209207,5.2880778 4.4222532,5.4980588 4.6049735,5.8776673 4.6690794,6.4269215 4.758728,6.938324 4.6867024,7.3632253 4.4502212,7.701886 3.7929448,8.642419 2.9376055,8.744677 1.884178,8.0085523 Z"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.24781px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path834"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccscscscc" />
+  <path
+     sodipodi:nodetypes="ccscscscc"
+     inkscape:connector-curvature="0"
+     id="path836"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.18558px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 7.9720657,14.959803 C 7.3940329,15.018715 6.8573722,14.839862 6.3638165,14.432079 5.9292468,13.955009 5.6837623,13.426201 5.6275342,12.847516 c -0.063012,-0.64347 0.139844,-1.246604 0.6053596,-1.810406 0.4590374,-0.628137 1.0097403,-0.973488 1.6534065,-1.034977 0.5144014,-0.044835 1.0569721,0.190527 1.6266561,0.720084 0.5640236,0.465426 0.8735956,0.987866 0.9286546,1.566264 0.147958,1.60822 -0.6701168,2.498027 -2.4703051,2.670442 z" />
+  <path
+     d="M 8.7159465,5.2729024 C 8.3394876,4.6457001 8.249757,3.9416655 8.4455696,3.1612914 8.7524332,2.4092053 9.2194634,1.8449443 9.8474761,1.4689332 10.544995,1.0516035 11.338977,0.953609 12.230846,1.1776005 c 0.961592,0.1816702 1.651203,0.6214088 2.068774,1.3183864 0.334396,0.5582422 0.353935,1.3033889 0.06221,2.2368829 C 14.13791,5.6242317 13.713015,6.2586173 13.085383,6.6344621 11.342522,7.678403 9.8863851,7.224374 8.7170378,5.2726456 Z"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.87708px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path838"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccscscscc" />
+</svg>

--- a/resources/img/scalable/actions/flypie-edit-trace-symbolic.svg
+++ b/resources/img/scalable/actions/flypie-edit-trace-symbolic.svg
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    version="1.1"
    id="svg881"
    sodipodi:docname="flypie-edit-trace-symbolic.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata887">
     <rdf:RDF>
@@ -21,7 +21,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,12 +37,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1131"
+     inkscape:window-height="1163"
      id="namedview883"
      showgrid="true"
-     inkscape:zoom="32.482718"
-     inkscape:cx="10.490266"
-     inkscape:cy="8.8579974"
+     inkscape:zoom="53.95614"
+     inkscape:cx="8.4513088"
+     inkscape:cy="6.838888"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -53,14 +53,15 @@
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-midpoints="true"
      inkscape:snap-center="true"
-     inkscape:snap-global="false">
+     inkscape:snap-global="false"
+     inkscape:pagecheckerboard="0">
     <inkscape:grid
        type="xygrid"
        id="grid900" />
   </sodipodi:namedview>
   <path
      d="M 0.63085605,13.136648 C 0.36462559,12.950616 0.2000805,12.681785 0.1378186,12.32946 0.1276805,11.968669 0.2127226,11.654896 0.39874656,11.388553 0.60557639,11.092529 0.91013012,10.908896 1.3123545,10.837667 c 0.4230937,-0.101009 0.7824046,-0.04794 1.0783693,0.159034 0.2370598,0.165193 0.3808068,0.463833 0.4312392,0.895934 0.070527,0.402323 0.013864,0.736595 -0.1721768,1.003021 -0.5170828,0.739922 -1.1899824,0.820369 -2.01871922,0.241256 z"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.24781px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:0.25;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.24781px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path834"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccscscscc" />
@@ -68,22 +69,24 @@
      sodipodi:nodetypes="ccscscscc"
      inkscape:connector-curvature="0"
      id="path836"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.18558px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:0.25;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.18558px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="M 9.4559204,11.207745 C 9.132484,11.240709 8.8321973,11.140633 8.5560299,10.912459 8.3128679,10.645516 8.1755079,10.349623 8.1440456,10.025822 8.1087872,9.6657705 8.2222948,9.3282886 8.4827726,9.0128152 8.7396254,8.6613426 9.0477693,8.4681028 9.4079307,8.4336967 c 0.2878316,-0.025087 0.5914252,0.106609 0.9101903,0.4029211 0.315597,0.2604278 0.488818,0.5527575 0.519625,0.8763978 0.08279,0.8998744 -0.374961,1.3977634 -1.3822508,1.4942374 z" />
   <path
-     d="M 11.710436,4.5869568 C 11.443413,4.1420816 11.379767,3.6427093 11.518657,3.0891892 11.736316,2.5557339 12.067581,2.155503 12.513031,1.888798 c 0.494751,-0.2960123 1.057923,-0.3655199 1.690526,-0.2066425 0.682059,0.1288588 1.1712,0.4407658 1.467384,0.9351326 0.237187,0.3959617 0.251046,0.9244949 0.04413,1.586623 -0.15883,0.6322439 -0.460208,1.0822141 -0.905389,1.3488012 -1.236214,0.7404682 -2.269053,0.418425 -3.098472,-0.9659377 z"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.87708px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 9.9060547,4.492618 C 9.5211617,3.8513652 9.4294207,3.1315591 9.6296197,2.3337032 9.9433587,1.5647692 10.420851,0.98786771 11.062933,0.60343331 c 0.713144,-0.42667853 1.524913,-0.52686829 2.43676,-0.29785896 0.983135,0.18573987 1.688193,0.63532936 2.11512,1.34792045 0.341886,0.5707477 0.361863,1.332587 0.06361,2.2869928 C 15.449482,4.8518177 15.01507,5.5004145 14.373376,5.8846789 12.59147,6.9520058 11.102714,6.4878058 9.9071707,4.4923553 Z"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;opacity:0.25;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:5.87708px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path838"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccscscscc" />
   <path
-     d="M 2.6794004,12.305645 Q 2.3380854,12.367531 2.0181242,12.268513 1.7407257,12.161085 1.7109917,11.944103 1.6681136,11.634534 4.3166071,10.861136 7.0031398,10.048784 8.8795676,9.7035073 9.2208941,9.6416028 9.5406837,9.7402202 9.8603713,9.840276 9.8905405,10.056632 9.9334173,10.366199 7.28925,11.170647 4.6409842,11.94395 2.6793576,12.305188 Z"
+     d="M 2.6794004,12.305645 C 2.4518571,12.346905 2.2314317,12.334525 2.0181242,12.268515 1.8331919,12.196895 1.7308144,12.08876 1.7109917,11.944105 1.6824067,11.737726 2.5509448,11.376737 4.3166071,10.861138 6.1076289,10.31957 8.2120047,9.7641383 9.549896,9.2091106 9.777447,9.1678406 9.3274906,9.6744773 9.5406837,9.7402222 9.7538088,9.8069262 9.8704277,9.9123967 9.8905405,10.056634 9.9191245,10.263012 9.0520282,10.63435 7.28925,11.170649 5.5237395,11.686184 3.9871087,12.064365 2.6793576,12.30519 Z"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:4.2528px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path823"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
   <path
-     d="M 10.181338,9.720662 Q 9.9670973,9.991647 9.6648436,10.122408 9.3888654,10.218848 9.226599,10.067896 8.9947508,9.8528433 10.467874,7.5199829 q 1.4763,-2.3882237 2.650874,-3.8819485 0.214241,-0.2710017 0.516098,-0.4019728 0.302715,-0.1297756 0.464903,0.020392 0.231848,0.2150479 -1.218006,2.569465 -1.473016,2.3326381 -2.700735,3.8944075 z"
+     d="M 10.233217,9.7244316 C 10.121349,9.9257316 9.9730001,10.085626 9.7881676,10.204116 9.6169385,10.297201 9.4181881,9.9344347 9.2952151,9.8525361 9.1195774,9.7359334 9.4428002,9.1994385 10.161585,7.5063328 10.876515,5.7764591 11.540204,4.3570572 12.15265,3.2481274 12.264515,3.0468153 12.412723,2.886867 12.597272,2.7682827 c 0.185242,-0.11789 0.339281,-0.1361398 0.462118,-0.054749 0.175637,0.1166005 -0.08713,1.0272961 -0.788283,2.7320868 -0.718739,1.6929479 -1.398162,3.1191252 -2.03827,4.2785319 z"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;fill:#2c2c2c;fill-opacity:1;stroke:none;stroke-width:4.2528px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3469"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/resources/ui/gtk3/settings.ui
+++ b/resources/ui/gtk3/settings.ui
@@ -4908,6 +4908,22 @@ This can be used if you want to capture a video of Fly-Pie.</property>
                                           <object class="GtkLabel">
                                             <property name="hexpand">1</property>
                                             <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Show Touch Button</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="touch-button" />
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="margin_top">10</property>
+                                        <property name="spacing">10</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="hexpand">1</property>
+                                            <property name="halign">start</property>
                                             <property name="label" translatable="yes">Open in Screen Center</property>
                                           </object>
                                         </child>

--- a/resources/ui/gtk3/settings.ui
+++ b/resources/ui/gtk3/settings.ui
@@ -350,6 +350,11 @@
     <property name="step_increment">1</property>
     <property name="page_increment">50</property>
   </object>
+  <object class="GtkAdjustment" id="touch-buttons-opacity">
+    <property name="upper">1</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.1</property>
+  </object>
 
   <object class="GtkSizeGroup">
     <property name="mode">horizontal</property>
@@ -3949,6 +3954,154 @@ will cancel the selection.</property>
                       <object class="GtkImage">
                         <property name="icon_name">flypie-edit-trace-symbolic</property>
                         <property name="tooltip_text" translatable="yes">Trace Appearance</property>
+                        <property name="pixel_size">32</property>
+                        <property name="vexpand">1</property>
+                      </object>
+                    </child>
+
+
+                    <!-- Touch Button Settings -->
+
+
+                    <child name="child">
+                      <object class="GtkGrid">
+                        <property name="margin_start">40</property>
+                        <property name="margin_end">40</property>
+                        <property name="margin_top">30</property>
+                        <property name="margin_bottom">30</property>
+                        <property name="row_spacing">10</property>
+                        <property name="column_spacing">5</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Touch Button Settings</property>
+                                <style>
+                                  <class name="large-title" />
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="margin_bottom">30</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">You can show a touch button for each of your menus.</property>
+                                <style>
+                                  <class name="dim-label" />
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="margin_end">20</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Inactive Opacity</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale">
+                            <property name="draw-value">1</property>
+                            <property name="hexpand">1</property>
+                            <property name="adjustment">touch-buttons-opacity</property>
+                            <property name="restrict_to_fill_level">0</property>
+                            <property name="fill_level">0</property>
+                            <property name="round_digits">2</property>
+                            <property name="digits">2</property>
+                            <property name="value_pos">left</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="margin_end">20</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Show in Overview Mode</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="touch-buttons-show-in-overview-mode">
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">5</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="margin_end">20</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Show in Desktop Mode</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="touch-buttons-show-in-desktop-mode">
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">6</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="margin_end">20</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Show above Fullscreen Windows</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">7</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="touch-buttons-show-above-fullscreen">
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">7</property>
+                          </packing>
+                        </child>
+
+                      </object>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkImage">
+                        <property name="icon_name">flypie-edit-touch-buttons-symbolic</property>
+                        <property name="tooltip_text" translatable="yes">Touch Button Settings</property>
                         <property name="pixel_size">32</property>
                         <property name="vexpand">1</property>
                       </object>

--- a/resources/ui/gtk3/settings.ui
+++ b/resources/ui/gtk3/settings.ui
@@ -3962,8 +3962,7 @@ will cancel the selection.</property>
 
                     <!-- Touch Button Settings -->
 
-
-                    <child name="child">
+                    <child>
                       <object class="GtkGrid">
                         <property name="margin_start">40</property>
                         <property name="margin_end">40</property>

--- a/resources/ui/gtk4/settings.ui
+++ b/resources/ui/gtk4/settings.ui
@@ -350,6 +350,11 @@
     <property name="step_increment">1</property>
     <property name="page_increment">50</property>
   </object>
+  <object class="GtkAdjustment" id="touch-buttons-opacity">
+    <property name="upper">1</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.1</property>
+  </object>
 
   <object class="GtkSizeGroup">
     <property name="mode">horizontal</property>
@@ -4009,11 +4014,165 @@ will cancel the selection.</property>
                           </object>
                         </child>
 
-                        <!-- Advanced Settings -->
+
+                        <!-- Touch Button Settings -->
 
                         <child>
                           <object class="GtkNotebookPage">
                             <property name="position">6</property>
+
+                            <property name="child">
+                              <object class="GtkGrid">
+                                <property name="margin_start">40</property>
+                                <property name="margin_end">40</property>
+                                <property name="margin_top">30</property>
+                                <property name="margin_bottom">30</property>
+                                <property name="row_spacing">10</property>
+                                <property name="column_spacing">5</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">2</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Touch Button Settings</property>
+                                        <style>
+                                          <class name="large-title" />
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="margin_bottom">30</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">You can show a touch button for each of your menus.</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                      <property name="column-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="margin_end">20</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Inactive Opacity</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">4</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkScale">
+                                    <property name="draw-value">1</property>
+                                    <property name="hexpand">1</property>
+                                    <property name="adjustment">touch-buttons-opacity</property>
+                                    <property name="restrict_to_fill_level">0</property>
+                                    <property name="fill_level">0</property>
+                                    <property name="round_digits">2</property>
+                                    <property name="digits">2</property>
+                                    <property name="value_pos">left</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">4</property>
+                                    </layout>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="margin_end">20</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Show in Overview Mode</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">5</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="touch-buttons-show-in-overview-mode">
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">5</property>
+                                    </layout>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="margin_end">20</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Show in Desktop Mode</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">6</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="touch-buttons-show-in-desktop-mode">
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">6</property>
+                                    </layout>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="margin_end">20</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Show above Fullscreen Windows</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">7</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="touch-buttons-show-above-fullscreen">
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">7</property>
+                                    </layout>
+                                  </object>
+                                </child>
+
+                              </object>
+                            </property>
+
+                            <property name="tab">
+                              <object class="GtkImage">
+                                <property name="icon_name">flypie-edit-touch-buttons-symbolic</property>
+                                <property name="tooltip_text" translatable="yes">Touch Button Settings</property>
+                                <property name="icon_size">2</property>
+                                <property name="vexpand">1</property>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+
+                        <!-- Advanced Settings -->
+
+                        <child>
+                          <object class="GtkNotebookPage">
+                            <property name="position">7</property>
 
                             <property name="child">
                               <object class="GtkGrid">

--- a/resources/ui/gtk4/settings.ui
+++ b/resources/ui/gtk4/settings.ui
@@ -4909,6 +4909,22 @@ This can be used if you want to capture a video of Fly-Pie.</property>
                                               <object class="GtkLabel">
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Show Touch Button</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="touch-button" />
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="margin_top">10</property>
+                                            <property name="spacing">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in Screen Center</property>
                                               </object>
                                             </child>

--- a/schemas/org.gnome.shell.extensions.flypie.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.flypie.gschema.xml
@@ -503,6 +503,12 @@
       <description>If set to true, touch buttons will be shown above fullscreen windows.</description>
     </key>
 
+    <key name="touch-button-positions" type="a(hhh)">
+      <default>[]</default>
+      <summary>Touch Button Positions</summary>
+      <description>The monitor number and pixel positions of the touch buttons.</description>
+    </key>
+
     <!-- Behavior Settings -->
 
     <key name="gesture-selection-timeout" type="d">

--- a/schemas/org.gnome.shell.extensions.flypie.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.flypie.gschema.xml
@@ -477,6 +477,32 @@
       <description>The color of the menu's trace.</description>
     </key>
 
+    <!-- Touch Button Settings -->
+
+    <key name="touch-buttons-opacity" type="d">
+      <default>0.3</default>
+      <summary>Touch button opacity</summary>
+      <description>Opacity on inactive touch buttons.</description>
+    </key>
+
+    <key name="touch-buttons-show-in-overview-mode" type="b">
+      <default>false</default>
+      <summary>Show touch buttons in overview mode</summary>
+      <description>If set to true, touch buttons are shown in overview mode.</description>
+    </key>
+
+    <key name="touch-buttons-show-in-desktop-mode" type="b">
+      <default>true</default>
+      <summary>Show touch buttons in desktop mode</summary>
+      <description>If set to true, touch buttons are shown in desktop mode.</description>
+    </key>
+
+    <key name="touch-buttons-show-above-fullscreen" type="b">
+      <default>false</default>
+      <summary>Show touch buttons above fullscreen</summary>
+      <description>If set to true, touch buttons will be shown above fullscreen windows.</description>
+    </key>
+
     <!-- Behavior Settings -->
 
     <key name="gesture-selection-timeout" type="d">

--- a/schemas/org.gnome.shell.extensions.flypie.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.flypie.gschema.xml
@@ -503,7 +503,7 @@
       <description>If set to true, touch buttons will be shown above fullscreen windows.</description>
     </key>
 
-    <key name="touch-button-positions" type="a(hhh)">
+    <key name="touch-button-positions" type="aah">
       <default>[]</default>
       <summary>Touch Button Positions</summary>
       <description>The monitor number and pixel positions of the touch buttons.</description>

--- a/src/common/DBusInterface.js
+++ b/src/common/DBusInterface.js
@@ -22,12 +22,24 @@ var DBusInterface = {
             <arg name="name"   type="s" direction="in"/>                                 \
             <arg name="menuID" type="i" direction="out"/>                                \
           </method>                                                                      \
+          <method name="ShowMenuAt">                                                     \
+            <arg name="name"   type="s" direction="in"/>                                 \
+            <arg name="x"      type="i" direction="in"/>                                 \
+            <arg name="y"      type="i" direction="in"/>                                 \
+            <arg name="menuID" type="i" direction="out"/>                                \
+          </method>                                                                      \
           <method name="PreviewMenu">                                                    \
             <arg name="name"   type="s" direction="in"/>                                 \
             <arg name="menuID" type="i" direction="out"/>                                \
           </method>                                                                      \
           <method name="ShowCustomMenu">                                                 \
             <arg name="description" type="s" direction="in"/>                            \
+            <arg name="menuID"      type="i" direction="out"/>                           \
+          </method>                                                                      \
+          <method name="ShowCustomMenuAt">                                               \
+            <arg name="description" type="s" direction="in"/>                            \
+            <arg name="x"           type="i" direction="in"/>                            \
+            <arg name="y"           type="i" direction="in"/>                            \
             <arg name="menuID"      type="i" direction="out"/>                           \
           </method>                                                                      \
           <method name="PreviewCustomMenu">                                              \

--- a/src/common/ItemRegistry.js
+++ b/src/common/ItemRegistry.js
@@ -318,11 +318,12 @@ var ItemRegistry = class ItemRegistry {
       config.icon = this.getItemTypes()[config.type].icon;
     }
 
-    // The 'shortcut' and the 'centered' property is only available on top-level items,
-    // the 'angle' property on all other items.
+    // The 'shortcut', 'touchButton', and 'centered' property is only available on
+    // top-level items, the 'angle' property on all other items.
     if (isToplevel) {
-      config.centered = config.centered != undefined ? config.centered : false;
-      config.shortcut = config.shortcut != undefined ? config.shortcut : '';
+      config.centered    = config.centered != undefined ? config.centered : false;
+      config.shortcut    = config.shortcut != undefined ? config.shortcut : '';
+      config.touchButton = config.touchButton != undefined ? config.touchButton : false;
     } else {
       config.angle = config.angle != undefined ? config.angle : -1;
     }

--- a/src/extension/Daemon.js
+++ b/src/extension/Daemon.js
@@ -140,7 +140,7 @@ var Daemon = class Daemon {
       // the menu if a statistics key changes, we have to manual filter here.
       if (Statistics.getInstance().containsAnyNonStatsKey(keys)) {
         this._menu.onSettingsChange();
-        this._touchButtons.onSettingsChange();
+        this._touchButtons.onSettingsChange(keys);
       }
 
       return false;

--- a/src/extension/Daemon.js
+++ b/src/extension/Daemon.js
@@ -242,7 +242,13 @@ var Daemon = class Daemon {
   // over the D-Bus. See the README.md for a description of Fly-Pie's DBusInterface. If
   // there are more than one menu with the same name, the first will be opened.
   ShowMenu(name) {
-    return this._openMenu(name, false);
+    return this.ShowMenuAt(name, null, null);
+  }
+
+  // Same as above, but instead at the pointer location, the menu will be opened at the
+  // given pixel coordinates.
+  ShowMenuAt(name, x, y) {
+    return this._openMenu(name, false, x, y);
   }
 
   // This opens a menu configured with Fly-Pie's menu editor in preview mode and can be
@@ -250,15 +256,21 @@ var Daemon = class Daemon {
   // DBusInterface. If there are more than one menu with the same name, the first will be
   // opened.
   PreviewMenu(name) {
-    return this._openMenu(name, true);
+    return this._openMenu(name, true, null, null);
   }
 
   // This opens a custom menu and can be directly called over the D-Bus.
   // See the README.md for a description of Fly-Pie's DBusInterface.
   ShowCustomMenu(json) {
+    return this.ShowCustomMenuAt(json, null, null);
+  }
+
+  // Same as above, but instead at the pointer location, the menu will be opened at the
+  // given pixel coordinates.
+  ShowCustomMenuAt(json, x, y) {
     this._lastMenuID = this._getNextMenuID(this._lastMenuID);
     Statistics.getInstance().addCustomDBusMenu();
-    return this._openCustomMenu(json, false, this._lastMenuID);
+    return this._openCustomMenu(json, false, this._lastMenuID, x, y);
   }
 
   // This opens a custom menu in preview mode and can be directly called over the D-Bus.
@@ -266,7 +278,7 @@ var Daemon = class Daemon {
   PreviewCustomMenu(json) {
     this._lastMenuID = this._getNextMenuID(this._lastMenuID);
     Statistics.getInstance().addCustomDBusMenu();
-    return this._openCustomMenu(json, true, this._lastMenuID);
+    return this._openCustomMenu(json, true, this._lastMenuID, null, null);
   }
 
   // This selects an item in the currently opened menu.
@@ -280,7 +292,7 @@ var Daemon = class Daemon {
   // Opens a menu configured with Fly-Pie's menu editor, optionally in preview mode. The
   // menu's name must be given as parameter. It will return a positive number on success
   // and a negative on failure. See common/DBusInterface.js for a list of error codes.
-  _openMenu(name, previewMode) {
+  _openMenu(name, previewMode, x, y) {
 
     // Search for the meu with the given name.
     for (let i = 0; i < this._menuConfigs.length; i++) {
@@ -290,7 +302,7 @@ var Daemon = class Daemon {
         // Once we found the desired menu, we can open the menu with the custom-menu
         // method.
         return this._openCustomMenu(
-            this._menuConfigs[i], previewMode, this._menuConfigs[i].id);
+            this._menuConfigs[i], previewMode, this._menuConfigs[i].id, x, y);
       }
     }
 
@@ -302,7 +314,7 @@ var Daemon = class Daemon {
   // be a JSON string or an object containing the menu configuration. This method will
   // return the menu's ID on success or an error code on failure. See
   // common/DBusInterface.js for a list of error codes.
-  _openCustomMenu(config, previewMode, menuID) {
+  _openCustomMenu(config, previewMode, menuID, x, y) {
 
     // First try to parse the menu configuration if it's given as a json string.
     if (typeof config === 'string') {
@@ -335,7 +347,7 @@ var Daemon = class Daemon {
     // Then try to open the menu. This will return the menu's ID on success or an error
     // code on failure.
     try {
-      return this._menu.show(menuID, structure, previewMode);
+      return this._menu.show(menuID, structure, previewMode, x, y);
     } catch (error) {
       utils.debug('Failed to show menu: ' + error);
     }

--- a/src/extension/Menu.js
+++ b/src/extension/Menu.js
@@ -407,9 +407,10 @@ var Menu = class Menu {
     return this._menuID;
   }
 
-  // This shows the menu, or updates the menu if it is already visible. Returns an error
-  // code if something went wrong. See DBusInerface.js for all possible error codes.
-  show(menuID, structure, previewMode) {
+  // This shows the menu, or updates the menu if it is already visible. If the pixel
+  // positions x and y are given, the menu will be shown at this position. Returns an
+  // error code if something went wrong. See DBusInerface.js for all possible error codes.
+  show(menuID, structure, previewMode, x, y) {
 
     // The menu is already active. Try to update the existing menu according to the new
     // structure and if that is successful, emit an onCancel signal for the current menu.
@@ -517,13 +518,18 @@ var Menu = class Menu {
         this._input.warpPointer(posX + this._background.x, posY + this._background.y);
       }
     } else {
-      const [pointerX, pointerY] = global.get_pointer();
-      const [clampedX, clampedY] = this._clampToToMonitor(
-          pointerX - this._background.x, pointerY - this._background.y, 10);
+
+      // Use pointer location if no coordinates are given.
+      if (x == null && y == null) {
+        [x, y] = global.get_pointer();
+      }
+
+      const [clampedX, clampedY] =
+          this._clampToToMonitor(x - this._background.x, y - this._background.y, 10);
       this._root.set_translation(clampedX, clampedY, 0);
       this._selectionWedges.set_translation(clampedX, clampedY, 0);
 
-      if (pointerX != clampedX || pointerY != clampedY) {
+      if (x != clampedX || y != clampedY) {
         this._input.warpPointer(
             clampedX + this._background.x, clampedY + this._background.y);
       }

--- a/src/extension/Menu.js
+++ b/src/extension/Menu.js
@@ -36,10 +36,11 @@ var Menu = class Menu {
   // The Menu is only instantiated once by the Daemon. It is re-used for each new incoming
   // ShowMenu request. The four parameters are callbacks which are fired when the
   // corresponding event occurs.
-  constructor(emitHoverSignal, emitUnhoverSignal, emitSelectSignal, emitCancelSignal) {
+  constructor(
+      settings, emitHoverSignal, emitUnhoverSignal, emitSelectSignal, emitCancelSignal) {
 
     // Create Gio.Settings object for org.gnome.shell.extensions.flypie.
-    this._settings = utils.createSettings();
+    this._settings = settings;
 
     // This is primarily for the statistics.
     this._timer = new Timer();
@@ -389,25 +390,13 @@ var Menu = class Menu {
       this.hide();
     });
 
-    // Whenever settings are changed, we adapt the currently shown menu accordingly.
-    this._settingsConnection = this._settings.connect('change-event', (o, keys) => {
-      // For historical reasons, all settings of Fly-Pie are included in one schema. This
-      // is a bit unfortunate, as we cannot easily listen only for appearance changes, as
-      // all statistics are included in the schema as well. To avoid reconfiguration of
-      // the menu if a statistics key changes, we have to manual filter here.
-      if (Statistics.getInstance().containsAnyNonStatsKey(keys)) {
-        this._onSettingsChange();
-      }
-    });
-
-    this._onSettingsChange();
+    this.onSettingsChange();
   }
 
   // This removes our root actor from GNOME Shell.
   destroy() {
     Main.layoutManager.removeChrome(this._background);
     this._background.destroy();
-    this._settings.disconnect(this._settingsConnection);
   }
 
   // -------------------------------------------------------------------- public interface
@@ -778,6 +767,22 @@ var Menu = class Menu {
     return 0;
   }
 
+
+  // This is called every time a settings key changes. This is simply forwarded to all
+  // items which need redrawing. This could definitely be optimized.
+  onSettingsChange() {
+
+    // Notify the selection wedges on the change.
+    this._selectionWedges.onSettingsChange(this._settings);
+
+    // Then call onSettingsChange() for each item of our menu. This ensures that the menu
+    // is instantly updated in preview mode.
+    if (this._root != undefined) {
+      this._root.onSettingsChange(this._settings);
+      this._root.redraw();
+    }
+  }
+
   // ----------------------------------------------------------------------- private stuff
 
   // This assigns IDs and angles to each and every item. It also ensures that the root
@@ -898,21 +903,6 @@ var Menu = class Menu {
 
     this._selectionWedges.set_translation(
         tipX - this._background.x, tipY - this._background.y, 0);
-  }
-
-  // This is called every time a settings key changes. This is simply forwarded to all
-  // items which need redrawing. This could definitely be optimized.
-  _onSettingsChange() {
-
-    // Notify the selection wedges on the change.
-    this._selectionWedges.onSettingsChange(this._settings);
-
-    // Then call onSettingsChange() for each item of our menu. This ensures that the menu
-    // is instantly updated in preview mode.
-    if (this._root != undefined) {
-      this._root.onSettingsChange(this._settings);
-      this._root.redraw();
-    }
   }
 
   // x and y are the center coordinates of a MenuItem. This method returns a new position

--- a/src/extension/TouchButtons.js
+++ b/src/extension/TouchButtons.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-const Main                 = imports.ui.main;
-const {Meta, Clutter, Gio} = imports.gi;
+const Main                       = imports.ui.main;
+const {Meta, Clutter, Gio, GLib} = imports.gi;
 
 const Me            = imports.misc.extensionUtils.getCurrentExtension();
 const utils         = Me.imports.src.common.utils;
@@ -170,7 +170,14 @@ var TouchButtons = class TouchButtons {
     this._touchButtons.forEach(button => button.destroy());
     this._touchButtons = [];
 
-    this._configs.forEach(config => {
+    let positions = this._settings.get_value('touch-button-positions').deep_unpack();
+
+    positions = [[-1, 12, 45], [12, 12, 12], [0, 1, -2]];
+
+    const data = new GLib.Variant('a(hhh)', positions);
+    this._settings.set_value('touch-button-positions', data);
+
+    this._configs.forEach((config, i) => {
       if (config.touchButton) {
         const actor = MenuItem.createIcon(
             this._cachedSettings.backgroundColor, this._cachedSettings.backgroundImage,
@@ -220,6 +227,8 @@ var TouchButtons = class TouchButtons {
             this._ease(actor, {opacity: 255});
             this._ease(actor, {scale_x: 1});
             this._ease(actor, {scale_y: 1});
+
+            utils.debug(`drop at ${actor.x}x${actor.y}`);
           }
         });
 

--- a/src/extension/TouchButtons.js
+++ b/src/extension/TouchButtons.js
@@ -8,38 +8,68 @@
 
 'use strict';
 
-const Main            = imports.ui.main;
-const {Meta, Clutter} = imports.gi;
+const Main                 = imports.ui.main;
+const {Meta, Clutter, Gio} = imports.gi;
 
-const Me       = imports.misc.extensionUtils.getCurrentExtension();
-const utils    = Me.imports.src.common.utils;
-const MenuItem = Me.imports.src.extension.MenuItem.MenuItem;
+const Me            = imports.misc.extensionUtils.getCurrentExtension();
+const utils         = Me.imports.src.common.utils;
+const DBusInterface = Me.imports.src.common.DBusInterface.DBusInterface;
+const MenuItem      = Me.imports.src.extension.MenuItem.MenuItem;
+
+const DBusWrapper = Gio.DBusProxy.makeProxyWrapper(DBusInterface.description);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////
+
+
+const INACTIVE_OPACITY = 50;
+const DRAG_OPACITY     = 100;
+const DRAG_SCALE       = 0.7;
 
 var TouchButtons = class TouchButtons {
 
   // ------------------------------------------------------------ constructor / destructor
 
   constructor(settings) {
+
     this._settings          = settings;
     this._touchButtons      = [];
     this._configs           = [];
     this._startupCompleteID = 0;
+    this._inOverview        = false;
+
+    // Connect to the server so that we can toggle the demo menu from the tutorial.
+    new DBusWrapper(
+        Gio.DBus.session, 'org.gnome.Shell', '/org/gnome/shell/extensions/flypie',
+        proxy => {
+          this._dbus = proxy;
+          this._dbus.connectSignal('OnSelect', () => this._toggleButtons(true));
+          this._dbus.connectSignal('OnCancel', () => this._toggleButtons(true));
+        });
+
+    this._shownOverviewID = Main.overview.connect('showing', () => {
+      this._toggleButtons(false);
+      this._inOverview = true;
+    });
+    this._hideOverviewID  = Main.overview.connect('hiding', () => {
+      this._toggleButtons(true);
+      this._inOverview = false;
+    });
 
     this.onSettingsChange();
   }
 
   destroy() {
     this._touchButtons.forEach(button => button.destroy());
-
     this._touchButtons = [];
 
     if (this._startupCompleteID) {
       Main.layoutManager.disconnect(this._startupCompleteID);
       this._startupCompleteID = 0;
     }
+
+    Main.overview.disconnect(this._shownOverviewID);
+    Main.overview.disconnect(this._hideOverviewID);
   }
 
   // -------------------------------------------------------------------- public interface
@@ -61,16 +91,15 @@ var TouchButtons = class TouchButtons {
 
     // clang-format off
     this._cachedSettings = {
-      globalScale:         globalScale,
-      easingDuration:      this._settings.get_double('easing-duration') * 1000,
-      textColor:           Clutter.Color.from_string(this._settings.get_string('text-color'))[1],
-      font:                this._settings.get_string('font'),
-      size:                this._settings.get_double('center-size-hover') * globalScale,
-      iconScale:           this._settings.get_double('center-icon-scale-hover'),
-      iconCrop:            this._settings.get_double('center-icon-crop-hover'),
-      iconOpacity:         this._settings.get_double('center-icon-opacity-hover'),
-      backgroundImage:     MenuItem.loadBackgroundImage(this._settings.get_string('center-background-image-hover'),
-                                                        this._settings.get_double('center-size-hover') * globalScale)
+      easingDuration:  this._settings.get_double('easing-duration') * 1000,
+      textColor:       Clutter.Color.from_string(this._settings.get_string('text-color'))[1],
+      font:            this._settings.get_string('font'),
+      size:            this._settings.get_double('center-size-hover') * globalScale,
+      iconScale:       this._settings.get_double('center-icon-scale-hover'),
+      iconCrop:        this._settings.get_double('center-icon-crop-hover'),
+      iconOpacity:     this._settings.get_double('center-icon-opacity-hover'),
+      backgroundImage: MenuItem.loadBackgroundImage(this._settings.get_string('center-background-image-hover'),
+                                                    this._settings.get_double('center-size-hover') * globalScale)
     };
     // clang-format on
 
@@ -108,8 +137,16 @@ var TouchButtons = class TouchButtons {
 
   // ----------------------------------------------------------------------- private stuff
 
+  _toggleButtons(enable) {
+    this._touchButtons.forEach(button => {
+      button.reactive = enable;
+      this._ease(button, {opacity: enable ? INACTIVE_OPACITY : 0});
+    });
+  }
+
   _createButtons() {
-    this.destroy();
+    this._touchButtons.forEach(button => button.destroy());
+    this._touchButtons = [];
 
     this._configs.forEach(config => {
       if (config.touchButton) {
@@ -121,18 +158,22 @@ var TouchButtons = class TouchButtons {
         actor.name     = `Fly-Pie TouchButton (${config.name})`;
         actor.width    = this._cachedSettings.size;
         actor.height   = this._cachedSettings.size;
-        actor.opacity  = 20;
-        actor.reactive = true;
+        actor.opacity  = this._inOverview ? 0 : INACTIVE_OPACITY;
+        actor.reactive = !this._inOverview;
 
         Main.layoutManager.addChrome(actor);
         this._touchButtons.push(actor);
 
-        actor.connect('enter-event', () => {
-          this._ease(actor, {opacity: 255});
+        actor.connect('enter-event', (a) => {
+          if (!a._dragging) {
+            this._ease(actor, {opacity: 255});
+          }
         });
 
-        actor.connect('leave-event', () => {
-          this._ease(actor, {opacity: 20});
+        actor.connect('leave-event', (a) => {
+          if (!a._dragging) {
+            this._ease(actor, {opacity: INACTIVE_OPACITY});
+          }
         });
 
         actor.connect('motion-event', (a, event) => {
@@ -159,7 +200,6 @@ var TouchButtons = class TouchButtons {
             this._ease(actor, {opacity: 255});
             this._ease(actor, {scale_x: 1});
             this._ease(actor, {scale_y: 1});
-            utils.debug('drop');
           }
         });
 
@@ -172,9 +212,9 @@ var TouchButtons = class TouchButtons {
             [x, y]     = action.get_coords();
             [ok, x, y] = actor.transform_stage_point(x, y);
             actor.set_pivot_point(x / actor.width, y / actor.height);
-            this._ease(actor, {opacity: 50});
-            this._ease(actor, {scale_x: 0.5});
-            this._ease(actor, {scale_y: 0.5});
+            this._ease(actor, {opacity: DRAG_OPACITY});
+            this._ease(actor, {scale_x: DRAG_SCALE});
+            this._ease(actor, {scale_y: DRAG_SCALE});
 
             actor._dragging   = true;
             actor._dragStartX = x;
@@ -190,7 +230,9 @@ var TouchButtons = class TouchButtons {
 
 
           } else if (state == Clutter.LongPressState.CANCEL) {
-            utils.debug('show!');
+            this._toggleButtons(false);
+            this._dbus.ShowMenuAtRemote(
+                config.name, actor.x + actor.width / 2, actor.y + actor.height / 2);
           }
         });
         actor.add_action(action);

--- a/src/extension/TouchButtons.js
+++ b/src/extension/TouchButtons.js
@@ -1,0 +1,207 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//        ___            _     ___                                                      //
+//        |   |   \/    | ) |  |           This software may be modified and distri-    //
+//    O-  |-  |   |  -  |   |  |-  -O      buted under the terms of the MIT license.    //
+//        |   |_  |     |   |  |_          See the LICENSE file for details.            //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const Main            = imports.ui.main;
+const {Meta, Clutter} = imports.gi;
+
+const Me       = imports.misc.extensionUtils.getCurrentExtension();
+const utils    = Me.imports.src.common.utils;
+const MenuItem = Me.imports.src.extension.MenuItem.MenuItem;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
+
+var TouchButtons = class TouchButtons {
+
+  // ------------------------------------------------------------ constructor / destructor
+
+  constructor(settings) {
+    this._settings          = settings;
+    this._touchButtons      = [];
+    this._configs           = [];
+    this._startupCompleteID = 0;
+
+    this.onSettingsChange();
+  }
+
+  destroy() {
+    this._touchButtons.forEach(button => button.destroy());
+
+    this._touchButtons = [];
+
+    if (this._startupCompleteID) {
+      Main.layoutManager.disconnect(this._startupCompleteID);
+      this._startupCompleteID = 0;
+    }
+  }
+
+  // -------------------------------------------------------------------- public interface
+
+  setMenuConfigs(configs) {
+    this._configs = configs;
+
+    if (Main.layoutManager._startingUp) {
+      this._startupCompleteID =
+          Main.layoutManager.connect('startup-complete', () => this._createButtons());
+    } else {
+      this._createButtons();
+    }
+  }
+
+  onSettingsChange() {
+
+    const globalScale = this._settings.get_double('global-scale');
+
+    // clang-format off
+    this._cachedSettings = {
+      globalScale:         globalScale,
+      easingDuration:      this._settings.get_double('easing-duration') * 1000,
+      textColor:           Clutter.Color.from_string(this._settings.get_string('text-color'))[1],
+      font:                this._settings.get_string('font'),
+      size:                this._settings.get_double('center-size-hover') * globalScale,
+      iconScale:           this._settings.get_double('center-icon-scale-hover'),
+      iconCrop:            this._settings.get_double('center-icon-crop-hover'),
+      iconOpacity:         this._settings.get_double('center-icon-opacity-hover'),
+      backgroundImage:     MenuItem.loadBackgroundImage(this._settings.get_string('center-background-image-hover'),
+                                                        this._settings.get_double('center-size-hover') * globalScale)
+    };
+    // clang-format on
+
+    const colorMode = this._settings.get_string('center-color-mode-hover');
+
+    // If the color mode is 'auto', we calculate an average color of the icon.
+    if (colorMode == 'auto') {
+
+      const iconName = this._settings.get_string('center-background-image-hover');
+
+      // Compute the average color on a smaller version of the icon.
+      const surface          = utils.createIcon(iconName, 24, this._cachedSettings.font, {
+        red: this._cachedSettings.textColor.red / 255,
+        green: this._cachedSettings.textColor.green / 255,
+        blue: this._cachedSettings.textColor.blue / 255
+      });
+      const [r, g, b]        = utils.getAverageIconColor(surface, 24);
+      const averageIconColor = new Clutter.Color({red: r, green: g, blue: b});
+
+      // Now we modify this color based on the configured luminance and saturation values.
+      const saturation = this._settings.get_double('center-auto-color-saturation-hover');
+      const luminance  = this._settings.get_double('center-auto-color-luminance-hover');
+      const opacity = this._settings.get_double('center-auto-color-opacity-hover') * 255;
+
+      this._cachedSettings.backgroundColor =
+          MenuItem.getAutoColor(averageIconColor, luminance, saturation, opacity);
+
+    } else {
+      this._cachedSettings.backgroundColor = Clutter.Color.from_string(
+          this._settings.get_string('center-fixed-color-hover'))[1];
+    }
+
+    this._createButtons();
+  }
+
+  // ----------------------------------------------------------------------- private stuff
+
+  _createButtons() {
+    this.destroy();
+
+    this._configs.forEach(config => {
+      if (config.touchButton) {
+        const actor = MenuItem.createIcon(
+            this._cachedSettings.backgroundColor, this._cachedSettings.backgroundImage,
+            this._cachedSettings.size, config.icon, this._cachedSettings.iconScale,
+            this._cachedSettings.iconCrop, this._cachedSettings.iconOpacity,
+            this._cachedSettings.textColor, this._cachedSettings.font);
+        actor.name     = `Fly-Pie TouchButton (${config.name})`;
+        actor.width    = this._cachedSettings.size;
+        actor.height   = this._cachedSettings.size;
+        actor.opacity  = 20;
+        actor.reactive = true;
+
+        Main.layoutManager.addChrome(actor);
+        this._touchButtons.push(actor);
+
+        actor.connect('enter-event', () => {
+          this._ease(actor, {opacity: 255});
+        });
+
+        actor.connect('leave-event', () => {
+          this._ease(actor, {opacity: 20});
+        });
+
+        actor.connect('motion-event', (a, event) => {
+          if (a._dragging) {
+            const [x, y] = event.get_coords();
+            a.x          = x - a._dragStartX;
+            a.y          = y - a._dragStartY;
+          }
+          return true;
+        });
+
+        actor.connect('button-release-event', (actor, event) => {
+          if (actor._dragging) {
+
+            const pointer =
+                Clutter.get_default_backend().get_default_seat().get_pointer();
+            pointer.ungrab();
+
+            global.end_modal(global.get_current_time());
+
+            global.display.set_cursor(Meta.Cursor.DEFAULT);
+
+            actor._dragging = false;
+            this._ease(actor, {opacity: 255});
+            this._ease(actor, {scale_x: 1});
+            this._ease(actor, {scale_y: 1});
+            utils.debug('drop');
+          }
+        });
+
+        const action = Clutter.ClickAction.new();
+        action.connect('long-press', (action, actor, state) => {
+          if (state == Clutter.LongPressState.QUERY) {
+            return true;
+          } else if (state == Clutter.LongPressState.ACTIVATE) {
+            let x, y, ok;
+            [x, y]     = action.get_coords();
+            [ok, x, y] = actor.transform_stage_point(x, y);
+            actor.set_pivot_point(x / actor.width, y / actor.height);
+            this._ease(actor, {opacity: 50});
+            this._ease(actor, {scale_x: 0.5});
+            this._ease(actor, {scale_y: 0.5});
+
+            actor._dragging   = true;
+            actor._dragStartX = x;
+            actor._dragStartY = y;
+
+            const pointer =
+                Clutter.get_default_backend().get_default_seat().get_pointer();
+            pointer.grab(actor);
+
+            global.begin_modal(global.get_current_time(), 0);
+
+            global.display.set_cursor(Meta.Cursor.DND_IN_DRAG);
+
+
+          } else if (state == Clutter.LongPressState.CANCEL) {
+            utils.debug('show!');
+          }
+        });
+        actor.add_action(action);
+      }
+    });
+  }
+
+  _ease(actor, params) {
+    actor.ease(Object.assign(params, {
+      duration: this._cachedSettings.easingDuration,
+      mode: Clutter.AnimationMode.EASE_OUT_QUAD
+    }));
+  }
+};

--- a/src/prefs/MenuEditorPage.js
+++ b/src/prefs/MenuEditorPage.js
@@ -571,6 +571,14 @@ var MenuEditorPage = class MenuEditorPage {
       }
     });
 
+    // For top-level menus, store the touch-button mode.
+    this._builder.get_object('touch-button').connect('notify::active', (widget) => {
+      if (!this._updatingSidebar) {
+        this._selectedItem.touchButton = widget.active;
+        this._saveMenuConfiguration();
+      }
+    });
+
     // For top-level menus, store whether they should be opened in the center of the
     // screen.
     this._builder.get_object('menu-centered').connect('notify::active', (widget) => {
@@ -809,6 +817,7 @@ var MenuEditorPage = class MenuEditorPage {
       if (toplevelSelected) {
         this._menuShortcutLabel.set_accelerator(this._selectedItem.shortcut || '');
         this._builder.get_object('menu-centered').active = this._selectedItem.centered;
+        this._builder.get_object('touch-button').active  = this._selectedItem.touchButton;
       } else {
         this._builder.get_object('item-angle').value = this._selectedItem.angle;
       }

--- a/src/prefs/MenuEditorPage.js
+++ b/src/prefs/MenuEditorPage.js
@@ -575,6 +575,19 @@ var MenuEditorPage = class MenuEditorPage {
     this._builder.get_object('touch-button').connect('notify::active', (widget) => {
       if (!this._updatingSidebar) {
         this._selectedItem.touchButton = widget.active;
+
+        const positions =
+            this._settings.get_value('touch-button-positions').deep_unpack();
+
+        const index = this._menuConfigs.indexOf(this._selectedItem);
+
+        if (positions.length > index && positions[index].length > 0) {
+          positions[index] = [];
+        }
+
+        const variant = new GLib.Variant('aah', positions);
+        this._settings.set_value('touch-button-positions', variant);
+
         this._saveMenuConfiguration();
       }
     });

--- a/src/prefs/MenuEditorPage.js
+++ b/src/prefs/MenuEditorPage.js
@@ -571,23 +571,31 @@ var MenuEditorPage = class MenuEditorPage {
       }
     });
 
-    // For top-level menus, store the touch-button mode.
+    // For top-level menus, store whether a touch button should be shown.
     this._builder.get_object('touch-button').connect('notify::active', (widget) => {
       if (!this._updatingSidebar) {
         this._selectedItem.touchButton = widget.active;
 
+        // We reset the touch button's position when this setting is toggled. This means
+        // if a touch button is disabled and then enabled again, it will be shown in the
+        // middle of the screen again. This prevents that touch buttons get lost outside
+        // of the screen area. This way, a user can always get them back.
+        // First, we get the current positions list.
         const positions =
             this._settings.get_value('touch-button-positions').deep_unpack();
 
+        // Then we reset the entry for the current menu.
         const index = this._menuConfigs.indexOf(this._selectedItem);
-
         if (positions.length > index && positions[index].length > 0) {
           positions[index] = [];
         }
 
+        // Then we save the updated position list.
         const variant = new GLib.Variant('aah', positions);
         this._settings.set_value('touch-button-positions', variant);
 
+        // Finally we store the updated menu configuration. This will trigger the
+        // re-creation of all touch buttons.
         this._saveMenuConfiguration();
       }
     });

--- a/src/prefs/Preset.js
+++ b/src/prefs/Preset.js
@@ -92,6 +92,10 @@ let presetKeys = [
   'trace-min-length',
   'trace-thickness',
   'trace-color',
+  'touch-buttons-opacity',
+  'touch-buttons-show-in-overview-mode',
+  'touch-buttons-show-in-desktop-mode',
+  'touch-buttons-show-above-fullscreen',
 ];
 
 var Preset = class Preset {

--- a/src/prefs/Preset.js
+++ b/src/prefs/Preset.js
@@ -93,9 +93,6 @@ let presetKeys = [
   'trace-thickness',
   'trace-color',
   'touch-buttons-opacity',
-  'touch-buttons-show-in-overview-mode',
-  'touch-buttons-show-in-desktop-mode',
-  'touch-buttons-show-above-fullscreen',
 ];
 
 var Preset = class Preset {

--- a/src/prefs/SettingsPage.js
+++ b/src/prefs/SettingsPage.js
@@ -170,11 +170,16 @@ var SettingsPage = class SettingsPage {
       this._copyToHover('grandchild-fixed-color');
     });
 
-
     // Trace Settings.
     this._bindColorButton('trace-color');
     this._bindSlider('trace-min-length');
     this._bindSlider('trace-thickness');
+
+    // Touch button settings.
+    this._bindSlider('touch-buttons-opacity');
+    this._bindSwitch('touch-buttons-show-in-overview-mode');
+    this._bindSwitch('touch-buttons-show-in-desktop-mode');
+    this._bindSwitch('touch-buttons-show-above-fullscreen');
 
     // Advanced Settings
     this._bindSlider('gesture-selection-timeout');


### PR DESCRIPTION
This adds the possibility to show floating buttons which will open Fly-Pie menus. It's still WIP, but things are taking shape :wink: 

- [x] Add an option to show a touch button to each toplevel menu.
- [x] Draw the touch buttons.
- [x] Open menu on click.
- [x] Open menu on drag.
- [x] Move touch button on long press.
- [x] Save touch button position.
- [x] Add some appearance options.
- [x] Fix GTK3 / GNOME 3.3x version.
- [x] Document the new code.   