### PR TITLE
Delayed revealing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ When the user presses <kbd>Ctrl</kbd>+<kbd>C</kbd>, the clipboard does not magic
 To store a history of copied things, Fly-Pie has to request the data from the current provider.
 However, it cannot know beforehand, in which format any receiving application would like to have the data.
 So it just makes some assumptions and stores the data in a quite commonly used format and hopes that the receiver will understand the format.
+* A new advanced setting has been added to **delay the visual appearance** of Fly-Pie menus. This allows selecting items without showing the menu resulting in a less disruptive workflow for expert users.
 * Fly-Pie will now attempt to **open windows at the current pointer location** in order to reduce mouse travel. Whenever an action is executed, Fly-Pie checks whether a window is opened within the next second. If this happens, the newly opened window is moved to the pointer.
 * Icons can now be given as [**base64 encoded data URIs**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 This allows creating menus with completely application defined icons.

--- a/resources/ui/gtk3/settings.ui
+++ b/resources/ui/gtk3/settings.ui
@@ -276,6 +276,13 @@
     <property name="step_increment">10</property>
     <property name="page_increment">100</property>
   </object>
+  <object class="GtkAdjustment" id="display-timeout">
+    <property name="lower">0</property>
+    <property name="upper">500</property>
+    <property name="value">0</property>
+    <property name="step_increment">10</property>
+    <property name="page_increment">100</property>
+  </object>
   <object class="GtkAdjustment" id="global-scale">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
@@ -4288,6 +4295,55 @@ This is multiplied by the Global Scale value.</property>
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid">
+                            <property name="row_spacing">2</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Display Timeout</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Menus will be shown after this many milliseconds.
+Use this to quickly select items without showing the menu.</property>
+                                <style>
+                                  <class name="dim-label" />
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale">
+                            <property name="draw-value">1</property>
+                            <property name="hexpand">1</property>
+                            <property name="adjustment">display-timeout</property>
+                            <property name="restrict_to_fill_level">0</property>
+                            <property name="fill_level">0</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value_pos">left</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>

--- a/resources/ui/gtk4/settings.ui
+++ b/resources/ui/gtk4/settings.ui
@@ -276,6 +276,13 @@
     <property name="step_increment">10</property>
     <property name="page_increment">100</property>
   </object>
+  <object class="GtkAdjustment" id="display-timeout">
+    <property name="lower">0</property>
+    <property name="upper">500</property>
+    <property name="value">0</property>
+    <property name="step_increment">10</property>
+    <property name="page_increment">100</property>
+  </object>
   <object class="GtkAdjustment" id="global-scale">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
@@ -4353,6 +4360,55 @@ This is multiplied by the Global Scale value.</property>
                                     <layout>
                                       <property name="column">1</property>
                                       <property name="row">4</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkGrid">
+                                    <property name="row_spacing">2</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Display Timeout</property>
+                                        <layout>
+                                          <property name="column">0</property>
+                                          <property name="row">0</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Menus will be shown after this many milliseconds.
+Use this to quickly select items without showing the menu.</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
+                                        <layout>
+                                          <property name="column">0</property>
+                                          <property name="row">1</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkScale">
+                                    <property name="draw-value">1</property>
+                                    <property name="hexpand">1</property>
+                                    <property name="adjustment">display-timeout</property>
+                                    <property name="restrict_to_fill_level">0</property>
+                                    <property name="fill_level">0</property>
+                                    <property name="round_digits">0</property>
+                                    <property name="digits">0</property>
+                                    <property name="value_pos">left</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">1</property>
                                     </layout>
                                   </object>
                                 </child>

--- a/schemas/org.gnome.shell.extensions.flypie.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.flypie.gschema.xml
@@ -511,6 +511,13 @@
 
     <!-- Behavior Settings -->
 
+    <key name="display-timeout" type="d">
+      <default>0</default>
+      <summary>Display Timeout</summary>
+      <description>Menus will be shown after this many milliseconds.
+                   Use this to quickly select items without showing the menu.</description>
+    </key>
+
     <key name="gesture-selection-timeout" type="d">
       <default>100</default>
       <summary>Gesture Selection Timeout</summary>

--- a/src/extension/Background.js
+++ b/src/extension/Background.js
@@ -125,7 +125,7 @@ class Background extends Clutter.Actor {
   // screen and is pushed as modal, grabbing the complete user input. In preview mode the
   // background covers only one half of the monitor. Furthermore, the control buttons are
   // shown.
-  show(previewMode) {
+  open(previewMode) {
 
     this._previewMode = previewMode;
 
@@ -166,7 +166,7 @@ class Background extends Clutter.Actor {
       // Remove any previous clips set in preview mode.
       this.remove_clip();
 
-      // Actually this show() method can be called multiple times to toggle preview mode.
+      // Actually this open() method can be called multiple times to toggle preview mode.
       // We only attempt to grab the input if we do not have it grabbed already.
       if (!this._isModal) {
 
@@ -185,15 +185,20 @@ class Background extends Clutter.Actor {
     // Make the background visible and clickable.
     this.reactive = true;
     this.visible  = true;
-    this.opacity  = 255;
 
     return true;
+  }
+
+  // The open() method above does not really show the background; it's still translucent.
+  // The actual revealing is done by this method.
+  reveal() {
+    this.opacity = 255;
   }
 
   // This hides the background again. A fade-out animation is used for the opacity, but
   // the input is immediately un-grabbed allowing the user to click through the fading
   // background.
-  hide() {
+  close() {
     // Un-grab the input.
     if (this._isModal) {
       Main.popModal(this);

--- a/src/extension/Daemon.js
+++ b/src/extension/Daemon.js
@@ -347,7 +347,7 @@ var Daemon = class Daemon {
     // Then try to open the menu. This will return the menu's ID on success or an error
     // code on failure.
     try {
-      return this._menu.show(menuID, structure, previewMode, x, y);
+      return this._menu.open(menuID, structure, previewMode, x, y);
     } catch (error) {
       utils.debug('Failed to show menu: ' + error);
     }
@@ -458,7 +458,7 @@ var Daemon = class Daemon {
 
       // Something went wrong in updating the preview. Let's hide it.
       this._onCancel(this._menu.getID());
-      this._menu.hide();
+      this._menu.close();
     }
   }
 

--- a/src/prefs/SettingsPage.js
+++ b/src/prefs/SettingsPage.js
@@ -182,6 +182,7 @@ var SettingsPage = class SettingsPage {
     this._bindSwitch('touch-buttons-show-above-fullscreen');
 
     // Advanced Settings
+    this._bindSlider('display-timeout');
     this._bindSlider('gesture-selection-timeout');
     this._bindSlider('gesture-jitter-threshold');
     this._bindSlider('gesture-min-stroke-length');


### PR DESCRIPTION
This adds a new advanced setting fixing #147. If the "Display Timeout" is set to a value > 0, a menu will only be shown if the pointer is not moving for this many milliseconds.