### PR TITLE
Touch input

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,8 +28,9 @@ This allows creating menus with completely application defined icons.
 
 #### Other Enhancements
 
-* Gesture detection has been improved. Really fast pointer movements should now be detected more reliably.
-* It is now possible to copy items in the menu editor under GTK3 by holding the <kbd>Ctrl</kbd> key while dragging.
+* **Better touch support**! Touch screens are now well-supported on Wayland and X11.
+* **Gesture detection has been improved**. Really fast pointer movements should now be detected more reliably.
+* It is now possible to **copy items in the menu editor** under GTK3 by holding the <kbd>Ctrl</kbd> key while dragging.
 
 #### Bug Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@ This allows creating menus with completely application defined icons.
 #### Other Enhancements
 
 * **Better touch support**! Touch screens are now well-supported on Wayland and X11.
+* **Support for tablets**! Pen input is now well-supported on Wayland and X11. On Wayland, multi-cursor setups should be working as well.
 * **Gesture detection has been improved**. Really fast pointer movements should now be detected more reliably.
 * It is now possible to **copy items in the menu editor** under GTK3 by holding the <kbd>Ctrl</kbd> key while dragging.
 

--- a/src/extension/SelectionWedges.js
+++ b/src/extension/SelectionWedges.js
@@ -343,11 +343,10 @@ class SelectionWedges extends Clutter.Actor {
   // This is called by the Menu when the user clicks somewhere on the background. It fires
   // either 'parent-selected-event' or 'child-selected-event' if the corresponding wedge
   // is hovered or 'cancel-selection-event' if the secondary mouse button is pressed.
-  onButtonReleaseEvent(event) {
-    if (event.get_button() == 1) {
+  onButtonReleaseEvent(button) {
+    if (button == 1) {
       this._emitSelection();
-
-    } else if (event.get_button() == 3) {
+    } else if (button == 3) {
       this.emit('cancel-selection-event');
     }
   }

--- a/src/extension/TouchButtons.js
+++ b/src/extension/TouchButtons.js
@@ -269,64 +269,84 @@ var TouchButtons = class TouchButtons {
               (Main.layoutManager.currentMonitor.height - actor.height) / 2;
         }
 
-        // Now we have to wire up some events. If the pointer enters the touch button, we
-        // make it fully opaque.
-        actor.connect('enter-event', (actor) => {
-          if (!actor._dragging) {
-            this._ease(actor, {opacity: 255});
-          }
-        });
-
-        // If the pointer leaves the touch button, we make it somewhat transparent.
-        actor.connect('leave-event', (actor) => {
-          if (!actor._dragging) {
-            this._ease(actor, {opacity: this._cachedSettings.opacity});
-          }
-        });
-
         // Update the actor's position when dragged around.
-        actor.connect('motion-event', (actor, event) => {
-          if (actor._dragging) {
-            const [x, y] = event.get_coords();
-            actor.x      = x - actor._dragStartX;
-            actor.y      = y - actor._dragStartY;
-          }
-          return true;
-        });
+        actor.connect('event', (actor, event) => {
+          if (event.type() == Clutter.EventType.MOTION ||
+              event.type() == Clutter.EventType.TOUCH_UPDATE) {
 
-        // The button-release event is used to end a drag operation.
-        actor.connect('button-release-event', (actor) => {
-          if (actor._dragging) {
-            actor._dragging = false;
-
-            // Release the pointer grab.
-            Clutter.get_default_backend().get_default_seat().get_pointer().ungrab();
-            global.end_modal(global.get_current_time());
-
-            // Use the normal cursor again.
-            global.display.set_cursor(Meta.Cursor.DEFAULT);
-
-            // Make the button's size and opacity "normal" again.
-            this._ease(actor, {opacity: 255});
-            this._ease(actor, {scale_x: 1});
-            this._ease(actor, {scale_y: 1});
-
-            // Now save the updated touch button position. We retrieve the current
-            // positions list and update the entry for currently dragged item.
-            const positions =
-                this._settings.get_value('touch-button-positions').deep_unpack();
-            positions[i] = [actor.x, actor.y];
-
-            // It can be possible that there are undefined entries before the current one,
-            // so we set them to [].
-            for (let j = 0; j < i; j++) {
-              positions[j] = positions[j] || [];
+            if (actor._dragging) {
+              const [x, y] = event.get_coords();
+              actor.x      = x - actor._dragStartX;
+              actor.y      = y - actor._dragStartY;
             }
-
-            // Save the updated positions.
-            const variant = new GLib.Variant('aah', positions);
-            this._settings.set_value('touch-button-positions', variant);
+            return Clutter.EVENT_STOP;
           }
+
+          // If the pointer leaves the touch button, we make it somewhat transparent.
+          if (event.type() == Clutter.EventType.LEAVE) {
+
+            // Make sure that the long-press action gets canceled.
+            actor.get_actions()[0].release();
+
+            if (!actor._dragging && !this._menuOpened) {
+              this._ease(actor, {opacity: this._cachedSettings.opacity});
+            }
+            return Clutter.EVENT_STOP;
+          }
+
+          // Now we have to wire up some events. If the pointer enters the touch button,
+          // we make it fully opaque.
+          if (event.type() == Clutter.EventType.ENTER) {
+            if (!actor._dragging) {
+              this._ease(actor, {opacity: 255});
+            }
+            return Clutter.EVENT_STOP;
+          }
+
+          // Reset the touch button state on button release / touch end events.
+          if (event.type() == Clutter.EventType.BUTTON_RELEASE ||
+              event.type() == Clutter.EventType.TOUCH_END) {
+
+            // Make sure that the long-press action gets canceled.
+            actor.get_actions()[0].release();
+
+            // The button-release event is used to end a drag operation.
+            if (actor._dragging) {
+              actor._dragging = false;
+
+              // Release the pointer grab.
+              Clutter.get_default_backend().get_default_seat().get_pointer().ungrab();
+              global.end_modal(global.get_current_time());
+
+              // Use the normal cursor again.
+              global.display.set_cursor(Meta.Cursor.DEFAULT);
+
+              // Make the button's size and opacity "normal" again.
+              this._ease(actor, {opacity: 255});
+              this._ease(actor, {scale_x: 1});
+              this._ease(actor, {scale_y: 1});
+
+              // Now save the updated touch button position. We retrieve the current
+              // positions list and update the entry for currently dragged item.
+              const positions =
+                  this._settings.get_value('touch-button-positions').deep_unpack();
+              positions[i] = [actor.x, actor.y];
+
+              // It can be possible that there are undefined entries before the current
+              // one, so we set them to [].
+              for (let j = 0; j < i; j++) {
+                positions[j] = positions[j] || [];
+              }
+
+              // Save the updated positions.
+              const variant = new GLib.Variant('aah', positions);
+              this._settings.set_value('touch-button-positions', variant);
+            }
+            return Clutter.EVENT_STOP;
+          }
+
+
+          return Clutter.EVENT_CONTINUE;
         });
 
         // This long-press action is used to initiate dragging as well es opening the
@@ -335,10 +355,23 @@ var TouchButtons = class TouchButtons {
         action.connect('long-press', (action, actor, state) => {
           // We support long presses.
           if (state == Clutter.LongPressState.QUERY) {
+
+            // This should not be necessary. For some reason, the long-press action is
+            // canceled directly after it started for touch events. With mouse input,
+            // everything works without these two lines, but to get touch input working,
+            // we have to grab the input here. It is released a few lines further below.
+            Clutter.get_default_backend().get_default_seat().get_pointer().grab(actor);
+            global.begin_modal(global.get_current_time(), 0);
+
             return true;
           }
+
+          // Second part of the workaround mentioned above.
+          Clutter.get_default_backend().get_default_seat().get_pointer().ungrab();
+          global.end_modal(global.get_current_time());
+
           // If the long press was executed, we initiate dragging of the actor.
-          else if (state == Clutter.LongPressState.ACTIVATE) {
+          if (state == Clutter.LongPressState.ACTIVATE) {
 
             // First we shrink the button a bit and make it translucent. The pivot point
             // for shrinking is the pointer position inside the actor.


### PR DESCRIPTION
This improves Fly-Pie's support for touch screens significantly, both on Wayland and X11.
- [x] Fix touch buttons on touch screens
- [x] Select items by touch-clicks
- [x] Select items by touch-drags
- [x] Close the menu with long-press.