### PR TITLE
Super+RMB

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 #### New Features
 
 * **Touch Buttons** can now be enabled for each configured menu. A touch button is a floating button which can be moved anywhere on your screen and will open the corresponding menu when activated. In fact, you do not need to click the button, you can also start dragging on the button in a specific direction to directly enter the marking mode of the menu.
+* **Open menus with <kbd>Super</kbd>+<kbd>RMB</kbd>**: You can now assign one of your menus to be opened when you press the right mouse button while holding down the <kbd>Super</kbd> key. This option then replaces the default window menu which would be opened with this combination.
 * New **Clipboard Menu**: This menu shows recently copied things.
 On selection, the respective item is pasted.
 The menu currently supports text, raster and vector images, and files copied from the file manager.

--- a/resources/ui/gtk3/settings.ui
+++ b/resources/ui/gtk3/settings.ui
@@ -5112,6 +5112,23 @@ This can be used if you want to capture a video of Fly-Pie.</property>
                                       <object class="GtkBox">
                                         <property name="margin_top">10</property>
                                         <property name="spacing">10</property>
+                                        <property name="tooltip_text" translatable="yes">Usually, Super + Right Mouse Button opens the window menu. With this setting, you can instead open a Fly-Pie menu.</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="hexpand">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Bind to Super + RMB</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="super-rmb" />
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="margin_top">10</property>
+                                        <property name="spacing">10</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="hexpand">1</property>

--- a/resources/ui/gtk4/settings.ui
+++ b/resources/ui/gtk4/settings.ui
@@ -5120,6 +5120,23 @@ This can be used if you want to capture a video of Fly-Pie.</property>
                                           <object class="GtkBox">
                                             <property name="margin_top">10</property>
                                             <property name="spacing">10</property>
+                                            <property name="tooltip_text" translatable="yes">Usually, Super + Right Mouse Button opens the window menu. With this setting, you can instead open a Fly-Pie menu.</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Bind to Super + RMB</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="super-rmb" />
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="margin_top">10</property>
+                                            <property name="spacing">10</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="hexpand">1</property>

--- a/src/common/InputManipulator.js
+++ b/src/common/InputManipulator.js
@@ -84,7 +84,8 @@ var InputManipulator = class InputManipulator {
       this._keyboard.notify_keyval(0, Clutter.KEY_Alt_R, Clutter.KeyState.RELEASED);
     }
 
-    if (modifiers & Gdk.ModifierType.SUPER_MASK) {
+    if ((modifiers & Gdk.ModifierType.MOD4_MASK) ||
+        (modifiers & Gdk.ModifierType.SUPER_MASK)) {
       this._keyboard.notify_keyval(0, Clutter.KEY_Super_L, Clutter.KeyState.RELEASED);
       this._keyboard.notify_keyval(0, Clutter.KEY_Super_R, Clutter.KeyState.RELEASED);
     }
@@ -104,8 +105,6 @@ var InputManipulator = class InputManipulator {
       this._keyboard.notify_keyval(0, Clutter.KEY_Alt_L, Clutter.KeyState.PRESSED);
     }
 
-    if (modifiers & Gdk.ModifierType.SUPER_MASK) {
-      this._keyboard.notify_keyval(0, Clutter.KEY_Super_L, Clutter.KeyState.PRESSED);
-    }
+    // The super key is special, as it opens the overview. We do not press it again...
   }
 };

--- a/src/common/InputManipulator.js
+++ b/src/common/InputManipulator.js
@@ -105,6 +105,9 @@ var InputManipulator = class InputManipulator {
       this._keyboard.notify_keyval(0, Clutter.KEY_Alt_L, Clutter.KeyState.PRESSED);
     }
 
-    // The super key is special, as it opens the overview. We do not press it again...
+    if ((modifiers & Gdk.ModifierType.MOD4_MASK) ||
+        (modifiers & Gdk.ModifierType.SUPER_MASK)) {
+      this._keyboard.notify_keyval(0, Clutter.KEY_Super_L, Clutter.KeyState.PRESSED);
+    }
   }
 };

--- a/src/common/ItemRegistry.js
+++ b/src/common/ItemRegistry.js
@@ -318,12 +318,13 @@ var ItemRegistry = class ItemRegistry {
       config.icon = this.getItemTypes()[config.type].icon;
     }
 
-    // The 'shortcut', 'touchButton', and 'centered' property is only available on
-    // top-level items, the 'angle' property on all other items.
+    // The 'shortcut', 'touchButton', 'superRMB', and 'centered' property is only
+    // available on top-level items, the 'angle' property on all other items.
     if (isToplevel) {
       config.centered    = config.centered != undefined ? config.centered : false;
       config.shortcut    = config.shortcut != undefined ? config.shortcut : '';
       config.touchButton = config.touchButton != undefined ? config.touchButton : false;
+      config.superRMB    = config.superRMB != undefined ? config.superRMB : false;
     } else {
       config.angle = config.angle != undefined ? config.angle : -1;
     }

--- a/src/extension/Daemon.js
+++ b/src/extension/Daemon.js
@@ -92,7 +92,8 @@ var Daemon = class Daemon {
     // This class manages the global shortcuts. Once one of the registered shortcuts is
     // pressed, the corresponding menu is shown via the ShowMenu() method. If an error
     // occurred, a notification is shown.
-    this._shortcuts = new Shortcuts((shortcut) => {
+    this._shortcuts = new Shortcuts();
+    this._shortcuts.connect('activated', (s, shortcut) => {
       for (let i = 0; i < this._menuConfigs.length; i++) {
         if (shortcut == this._menuConfigs[i].shortcut) {
           const result = this.ShowMenu(this._menuConfigs[i].name);
@@ -103,6 +104,11 @@ var Daemon = class Daemon {
           }
         }
       }
+    });
+
+    this._shortcuts.connect('super-rmb', (s, shortcut) => {
+      utils.debug('super-rmb!');
+      return true;
     });
 
     // Create the touch buttons.

--- a/src/extension/Daemon.js
+++ b/src/extension/Daemon.js
@@ -117,12 +117,16 @@ var Daemon = class Daemon {
     // Open a menu when the Super+RMB combination is pressed and a menu is configured to
     // listen to it.
     this._shortcuts.connect('super-rmb', () => {
-      for (let i = 0; i < this._menuConfigs.length; i++) {
-        if (this._menuConfigs[i].superRMB) {
-          showMenu(this._menuConfigs[i].name);
+      // Do not attempt to open a new menu if one is already opened.
+      if (this._menu.getID() == null) {
+        for (let i = 0; i < this._menuConfigs.length; i++) {
+          if (this._menuConfigs[i].superRMB) {
+            showMenu(this._menuConfigs[i].name);
 
-          // We have a menu bound to Super+RMB, so we have to prevent the normal behavior.
-          return true;
+            // We have a menu bound to Super+RMB, so we have to prevent the normal
+            // behavior.
+            return true;
+          }
         }
       }
 

--- a/src/extension/Menu.js
+++ b/src/extension/Menu.js
@@ -189,7 +189,15 @@ var Menu = class Menu {
       // Touch-end events are handled as if the left mouse button was released.
       if (event.type() == Clutter.EventType.BUTTON_RELEASE ||
           event.type() == Clutter.EventType.TOUCH_END) {
-        emitSelection();
+        // Only emit selection events if no modifier buttons are still held down. Without,
+        // the main issue is that releasing the Super key after the Fly-Pie menus has been
+        // closed would lead to toggling the overview.
+        const turboModifiers =
+            Gtk.accelerator_get_default_mod_mask() | Clutter.ModifierType.MOD4_MASK;
+
+        if ((event.get_state() & turboModifiers) == 0) {
+          emitSelection();
+        }
         return Clutter.EVENT_STOP;
       }
 

--- a/src/extension/MouseHighlight.js
+++ b/src/extension/MouseHighlight.js
@@ -97,7 +97,9 @@ class MouseHighlight extends Clutter.Actor {
       ctx.lineTo(dx, dy);
       ctx.lineTo(ax, ay);
 
-      if (this._mods & Clutter.ModifierType.BUTTON3_MASK) {
+      // The right mouse button is BUTTON2 on Wayland and BUTTON3 on X11...
+      if (this._mods & Clutter.ModifierType.BUTTON2_MASK ||
+          this._mods & Clutter.ModifierType.BUTTON3_MASK) {
         ctx.setSourceRGB(1.0, 0.5, 0.5);
       } else {
         ctx.setSourceRGB(0.2, 0.2, 0.2);

--- a/src/extension/SelectionWedges.js
+++ b/src/extension/SelectionWedges.js
@@ -516,14 +516,17 @@ class SelectionWedges extends Clutter.Actor {
   // the "Turbo-Mode"). Thanks to the Super+RMB mode, we can actually select items with
   // the right mouse button...
   isGestureModifier(mods) {
-    const hoverMode          = this._settings.hoverMode;
-    const leftButtonPressed  = (mods & Clutter.ModifierType.BUTTON1_MASK) > 0;
-    const rightButtonPressed = (mods & Clutter.ModifierType.BUTTON3_MASK) > 0;
+    const hoverMode = this._settings.hoverMode;
+    const buttonPressed =
+        (mods &
+         (Clutter.ModifierType.BUTTON1_MASK | Clutter.ModifierType.BUTTON2_MASK |
+          Clutter.ModifierType.BUTTON3_MASK)) > 0;
+
     const shortcutPressed =
         (mods &
          (Gtk.accelerator_get_default_mod_mask() | Clutter.ModifierType.MOD4_MASK)) > 0;
 
-    return hoverMode || leftButtonPressed || rightButtonPressed || shortcutPressed;
+    return hoverMode || buttonPressed || shortcutPressed;
   }
 
   // ----------------------------------------------------------------------- private stuff

--- a/src/extension/Shortcuts.js
+++ b/src/extension/Shortcuts.js
@@ -31,7 +31,8 @@ var Shortcuts = GObject.registerClass(
       Properties: {},
       Signals: {
         'activated': {param_types: [GObject.TYPE_STRING]},
-        'super-rmb': {return_type: GObject.TYPE_BOOLEAN},
+        'super-rmb':
+            {return_type: GObject.TYPE_BOOLEAN, flags: GObject.SignalFlags.RUN_LAST},
       }
     },
 

--- a/src/extension/Shortcuts.js
+++ b/src/extension/Shortcuts.js
@@ -63,7 +63,7 @@ var Shortcuts = GObject.registerClass(
         const me                = this;
         Main.wm._windowMenuManager.showWindowMenuForWindow = function(...params) {
           const mods = global.get_pointer()[2];
-          if (mods & Clutter.ModifierType.MOD4_MASK == 0) {
+          if ((mods & Clutter.ModifierType.MOD4_MASK) == 0) {
             me._oldShowWindowMenu.apply(this, params);
             return;
           }

--- a/src/extension/Shortcuts.js
+++ b/src/extension/Shortcuts.js
@@ -79,7 +79,7 @@ var Shortcuts = GObject.registerClass(
           if (event.type() == Clutter.EventType.BUTTON_PRESS &&
               (event.get_state() & Clutter.ModifierType.MOD4_MASK) > 0) {
 
-            if ((event.get_state() & Clutter.ModifierType.BUTTON3_MASK) > 0) {
+            if (event.get_button() == 3) {
               if (this.emit('super-rmb')) {
                 return Clutter.EVENT_STOP;
               }

--- a/src/prefs/MenuEditorPage.js
+++ b/src/prefs/MenuEditorPage.js
@@ -571,6 +571,16 @@ var MenuEditorPage = class MenuEditorPage {
       }
     });
 
+    // For top-level menus, store whether they should be bound to Super + Right Mouse
+    // Button. Only one menu can be bound to Super+RMB, therefore we unbind all others.
+    this._builder.get_object('super-rmb').connect('notify::active', (widget) => {
+      if (!this._updatingSidebar) {
+        this._menuConfigs.forEach(config => config.superRMB = false);
+        this._selectedItem.superRMB = widget.active;
+        this._saveMenuConfiguration();
+      }
+    });
+
     // For top-level menus, store whether a touch button should be shown.
     this._builder.get_object('touch-button').connect('notify::active', (widget) => {
       if (!this._updatingSidebar) {
@@ -839,6 +849,7 @@ var MenuEditorPage = class MenuEditorPage {
         this._menuShortcutLabel.set_accelerator(this._selectedItem.shortcut || '');
         this._builder.get_object('menu-centered').active = this._selectedItem.centered;
         this._builder.get_object('touch-button').active  = this._selectedItem.touchButton;
+        this._builder.get_object('super-rmb').active     = this._selectedItem.superRMB;
       } else {
         this._builder.get_object('item-angle').value = this._selectedItem.angle;
       }


### PR DESCRIPTION
This allows opening menus with the <kbd>Super</kbd>+<kbd>RMB</kbd> combination. With this, it fixes #149. If required some refactoring as it was not possible before to select things with the right mouse button. Now the behavior in this regard is a bit different: The right mouse button still cancels when clicked, but can be used for selections by dragging (in the so-called Turbo-Mode).

I will spend some time to investigate whether  <kbd>Super</kbd>+<kbd>LMB</kbd> could be possible as well...