### PR TITLE
:beetle: Fix a bug, see comment

### DIFF
--- a/src/extension/Menu.js
+++ b/src/extension/Menu.js
@@ -663,6 +663,10 @@ var Menu = class Menu {
     });
     this._selectionWedges.setItemAngles(itemAngles);
 
+    // Reset the stroke coordinates in case a menu was previously closed without any
+    // selection made and SelectionWedges contains previous stroke.
+    this._selectionWedges._resetStroke();
+
     // Calculate menu position. We open the menu in the middle of the screen if necessary
     // accounting background position as well. Else we position it at the mouse pointer
     // accounting background position as well.

--- a/src/extension/Menu.js
+++ b/src/extension/Menu.js
@@ -665,7 +665,7 @@ var Menu = class Menu {
 
     // Reset the stroke coordinates in case a menu was previously closed without any
     // selection made and SelectionWedges contains previous stroke.
-    this._selectionWedges._resetStroke();
+    this._selectionWedges.resetStroke();
 
     // Calculate menu position. We open the menu in the middle of the screen if necessary
     // accounting background position as well. Else we position it at the mouse pointer

--- a/src/extension/SelectionWedges.js
+++ b/src/extension/SelectionWedges.js
@@ -347,7 +347,7 @@ class SelectionWedges extends Clutter.Actor {
   // This emits 'parent-selected-event' or 'child-selected-event' depending on the
   // currently hovered wedge. It also resets the current gesture detection.
   emitSelection(coords, fromGesture = false) {
-    this._resetStroke();
+    this.resetStroke();
 
     if (this._hoveredWedge >= 0) {
       if (this._hoveredWedge == this._parentIndex) {
@@ -525,7 +525,7 @@ class SelectionWedges extends Clutter.Actor {
       }
     } else {
       // The mouse button is not pressed anymore, so we can abort gesture detection.
-      this._resetStroke();
+      this.resetStroke();
     }
   }
 
@@ -547,6 +547,18 @@ class SelectionWedges extends Clutter.Actor {
     return hoverMode || buttonPressed || shortcutPressed;
   }
 
+  // Resets the current gesture detection. This is done when an item was selected or the
+  // mouse pointer released.
+  resetStroke() {
+    if (this._stroke.pauseTimeout != null) {
+      GLib.source_remove(this._stroke.pauseTimeout);
+      this._stroke.pauseTimeout = null;
+    }
+
+    this._stroke.start = null;
+    this._stroke.end   = null;
+  }
+
   // ----------------------------------------------------------------------- private stuff
 
   // Clutter.ShaderEffect.set_uniform_value() works well if floating point Numbers are
@@ -559,17 +571,5 @@ class SelectionWedges extends Clutter.Actor {
       value += 0.0000001;
     }
     this._wedgeShader.set_uniform_value(name, value);
-  }
-
-  // Resets the current gesture detection. This is done when an item was selected or the
-  // mouse pointer released.
-  _resetStroke() {
-    if (this._stroke.pauseTimeout != null) {
-      GLib.source_remove(this._stroke.pauseTimeout);
-      this._stroke.pauseTimeout = null;
-    }
-
-    this._stroke.start = null;
-    this._stroke.end   = null;
   }
 });


### PR DESCRIPTION
I encountered a bug which caused some premature selections to be made sometimes. Initially, I noticed it like that - opening a menu and making a singular stroke would sometimes cause two consecutive selections (a child and a grandchild) to be made. 

After some debugging, I figured out that it was made possible by two things - the first is the duplication of selections in the SelectionWedges class. The logic of the class allows both an angle-based selection and a halt-based selection to be made - there are two consecutive checks, not wrapped in an if-else statement. That does not cause the undesired behaviout in itself, so I didn't change that.

The second reason is that I would sometimes close the menu without making a selection and the old value of stroke would not be erased. So while stroke.end would be regularly updated, stroke.begin would not - it is set when stroke is null. 

Vector SE becomes undefined and causes havok.  This is how a singular straight stroke would trigger an angle-based selection.

My idea of a fix is to reset stroke upon opening a menu, but maybe it should be done in closeMenu() method.