### PR TITLE
:tada: Add to RunningApps so hoverPeeking minimizes if wasn't already open @IJK9827

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 #### Enhancements
 
 * All included SVG files have been optimized to reduce the size of the installed extension.
+* In RunningApps, hoverPeeking minimizes if window wasnt already open.
 
 #### Bug Fixes
 

--- a/src/common/menus/RunningApps.js
+++ b/src/common/menus/RunningApps.js
@@ -180,22 +180,26 @@ var menu = {
         parentMenu.children.push({
           name: window.get_title(),
           icon: icon,
-
+          wasMinimized: false,
           // If selected, we switch to the corresponding window. If window peeking is
           // enabled, this is not required as the hover event was fired already.
           onSelect: () => {
-            if (!data.hoverPeeking) {
-              window.get_workspace().activate_with_focus(
-                  window, global.display.get_current_time_roundtrip());
-            }
+            window.get_workspace().activate_with_focus(
+                window, global.display.get_current_time_roundtrip());
           },
 
           // If hovered, we switch to the corresponding window if window peeking is
           // enabled.
           onHover: () => {
             if (data.hoverPeeking) {
+              this.wasMinimized = window.minimized;
               window.get_workspace().activate_with_focus(
                   window, global.display.get_current_time_roundtrip());
+            }
+          },
+          onUnhover: () => {
+            if (data.hoverPeeking && this.wasMinimized) {
+              window.minimize();
             }
           }
         });


### PR DESCRIPTION
Add to RunningApps so hoverPeeking minimizes if wasn't already open. Sorry for the weird revert thing for emoji and paste tense. I think you could cherry pick commits for only the last one maybe.